### PR TITLE
Fix ArgoCD

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: v0.2.19
-appVersion: v0.2.19
+version: v0.2.20
+appVersion: v0.2.20
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -84,6 +84,11 @@ spec:
     parameters:
     - name: hostpathMapper.enabled
       value: 'true'
+    - name: autoDeletePersistentVolumeClaims
+      value: 'true'
+    # This will be valid from v0.20 onward
+    #- name: controlPlane.statefulSet.persistence.volumeClaim.retentionPolicy
+    #  value: Delete
 ---
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: HelmApplication

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	github.com/spdx/tools-golang v0.5.3
 	github.com/spf13/pflag v1.0.5
-	github.com/unikorn-cloud/core v0.1.49
+	github.com/unikorn-cloud/core v0.1.52
 	github.com/unikorn-cloud/identity v0.2.11
 	github.com/unikorn-cloud/rbac v0.1.1
 	github.com/unikorn-cloud/region v0.1.9

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v0.1.49 h1:ahAxrzvBnBICi+qN/AmTqKRJHpxl958gKVfBO3lz4G8=
-github.com/unikorn-cloud/core v0.1.49/go.mod h1:cP39UQN7aSmsfjQuSMsworI4oBIwx4oA4u20CbPpfZw=
+github.com/unikorn-cloud/core v0.1.52 h1:J8C8MBT3vYa5LUGHoWgzJ+UMPKcTtm9BfKgVKkG3f3w=
+github.com/unikorn-cloud/core v0.1.52/go.mod h1:cP39UQN7aSmsfjQuSMsworI4oBIwx4oA4u20CbPpfZw=
 github.com/unikorn-cloud/identity v0.2.11 h1:q6mkJ3qTRjwhlvLS9Jv0I4wlJhnsbJZHu2rbNdnXBYk=
 github.com/unikorn-cloud/identity v0.2.11/go.mod h1:4KHNdHiIKpKERD0slunDDXhdC59M7eiN+Y1wSfHbQwQ=
 github.com/unikorn-cloud/rbac v0.1.1 h1:5QB3YzwG0FaH80FirdwZLm8hwsxLN0iPCY9i1VVZjXY=

--- a/pkg/provisioners/managers/clustermanager/provisioner.go
+++ b/pkg/provisioners/managers/clustermanager/provisioner.go
@@ -26,7 +26,6 @@ import (
 	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	coreclient "github.com/unikorn-cloud/core/pkg/client"
 	"github.com/unikorn-cloud/core/pkg/provisioners"
-	"github.com/unikorn-cloud/core/pkg/provisioners/concurrent"
 	"github.com/unikorn-cloud/core/pkg/provisioners/remotecluster"
 	"github.com/unikorn-cloud/core/pkg/provisioners/serial"
 	unikornv1 "github.com/unikorn-cloud/kubernetes/pkg/apis/unikorn/v1alpha1"
@@ -122,7 +121,9 @@ func (p *Provisioner) getClusterManagerProvisioner() provisioners.Provisioner {
 
 	remoteClusterManager := remotecluster.New(vcluster.NewRemoteCluster(p.clusterManager.Namespace, p.clusterManager.Name, &p.clusterManager), true)
 
-	clusterAPIProvisioner := concurrent.New("cluster-api",
+	// **** sake https://github.com/argoproj/argo-cd/issues/18041
+	// This should be a concurrent provision, but alas no.
+	clusterAPIProvisioner := serial.New("cluster-api",
 		certmanager.New(apps.certManager),
 		clusterapi.New(apps.clusterAPI),
 	)


### PR DESCRIPTION
Argo will now crap out fatally when it sees a resource type without the correcsponding CRD being installed yet, so we need to wait for cert-manager to be installed before installing CAPI.  Then we need to wait for all that to be working before creating the Kubernetes cluster. Then I discovered (again) the vcluster PVC is not cleaned up.