### PR TITLE
Generate vcluster Name

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: v0.2.20
-appVersion: v0.2.20
+version: v0.2.21
+appVersion: v0.2.21
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/kubernetes/crds/unikorn-cloud.org_kubernetesclusters.yaml
+++ b/charts/kubernetes/crds/unikorn-cloud.org_kubernetesclusters.yaml
@@ -283,6 +283,11 @@ spec:
                   flavorId:
                     description: Flavor is the OpenStack Nova flavor to deploy with.
                     type: string
+                  flavorName:
+                    description: |-
+                      FlavorName is the name of the flavor.
+                      CAPO is broken and doesn't accept an ID, so we need to use this.
+                    type: string
                   imageId:
                     description: Image is the OpenStack Glance image to deploy with.
                     type: string
@@ -303,6 +308,7 @@ spec:
                     type: string
                 required:
                 - flavorId
+                - flavorName
                 - imageId
                 type: object
               features:
@@ -524,6 +530,11 @@ spec:
                           description: Flavor is the OpenStack Nova flavor to deploy
                             with.
                           type: string
+                        flavorName:
+                          description: |-
+                            FlavorName is the name of the flavor.
+                            CAPO is broken and doesn't accept an ID, so we need to use this.
+                          type: string
                         imageId:
                           description: Image is the OpenStack Glance image to deploy
                             with.
@@ -555,6 +566,7 @@ spec:
                           type: string
                       required:
                       - flavorId
+                      - flavorName
                       - imageId
                       - name
                       type: object

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -206,6 +206,9 @@ type MachineGeneric struct {
 	ImageID *string `json:"imageId"`
 	// Flavor is the OpenStack Nova flavor to deploy with.
 	FlavorID *string `json:"flavorId"`
+	// FlavorName is the name of the flavor.
+	// CAPO is broken and doesn't accept an ID, so we need to use this.
+	FlavorName *string `json:"flavorName"`
 	// DiskSize is the persistent root disk size to deploy with.  This
 	// overrides the default ephemeral disk size defined in the flavor.
 	DiskSize *resource.Quantity `json:"diskSize,omitempty"`

--- a/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
@@ -888,6 +888,11 @@ func (in *MachineGeneric) DeepCopyInto(out *MachineGeneric) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.FlavorName != nil {
+		in, out := &in.FlavorName, &out.FlavorName
+		*out = new(string)
+		**out = **in
+	}
 	if in.DiskSize != nil {
 		in, out := &in.DiskSize, &out.DiskSize
 		x := (*in).DeepCopy()

--- a/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
@@ -53,7 +53,7 @@ var _ application.PostProvisionHook = &Provisioner{}
 func (p *Provisioner) generateMachineHelmValues(machine *unikornv1.MachineGeneric, failureDomain *string) map[string]interface{} {
 	object := map[string]interface{}{
 		"imageID":  *machine.ImageID,
-		"flavorID": *machine.FlavorID,
+		"flavorID": *machine.FlavorName,
 	}
 
 	if failureDomain != nil {

--- a/pkg/provisioners/helmapplications/vcluster/provisioner.go
+++ b/pkg/provisioners/helmapplications/vcluster/provisioner.go
@@ -18,6 +18,8 @@ limitations under the License.
 package vcluster
 
 import (
+	"context"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/unikorn-cloud/core/pkg/provisioners/application"
@@ -43,7 +45,13 @@ func init() {
 	metrics.Registry.MustRegister(durationMetric)
 }
 
+type Provisioner struct{}
+
+func (*Provisioner) ReleaseName(ctx context.Context) string {
+	return releaseName(application.FromContext(ctx).GetName())
+}
+
 // New returns a new initialized provisioner object.
 func New(getApplication application.GetterFunc, name string) *application.Provisioner {
-	return application.New(getApplication)
+	return application.New(getApplication).WithGenerator(&Provisioner{})
 }

--- a/pkg/provisioners/helmapplications/vcluster/remotecluster.go
+++ b/pkg/provisioners/helmapplications/vcluster/remotecluster.go
@@ -76,5 +76,5 @@ func (g *RemoteCluster) ID() *cd.ResourceIdentifier {
 
 // Config implements the remotecluster.Generator interface.
 func (g *RemoteCluster) Config(ctx context.Context) (*clientcmdapi.Config, error) {
-	return NewControllerRuntimeClient().ClientConfig(ctx, g.namespace, false)
+	return NewControllerRuntimeClient().ClientConfig(ctx, g.namespace, g.name, false)
 }

--- a/pkg/server/handler/cluster/conversion.go
+++ b/pkg/server/handler/cluster/conversion.go
@@ -208,7 +208,7 @@ func (c *Client) generateNetwork() *unikornv1.KubernetesClusterNetworkSpec {
 }
 
 // generateMachineGeneric generates a generic machine part of the cluster.
-func (c *Client) generateMachineGeneric(ctx context.Context, organizationID, projectID string, options *openapi.KubernetesClusterSpec, m *openapi.MachinePool, flavorName string) (*unikornv1.MachineGeneric, error) {
+func (c *Client) generateMachineGeneric(ctx context.Context, organizationID, projectID string, options *openapi.KubernetesClusterSpec, m *openapi.MachinePool, flavor *regionapi.Flavor) (*unikornv1.MachineGeneric, error) {
 	if m.Replicas == nil {
 		m.Replicas = util.ToPointer(3)
 	}
@@ -222,7 +222,8 @@ func (c *Client) generateMachineGeneric(ctx context.Context, organizationID, pro
 		Replicas: m.Replicas,
 		ImageID:  util.ToPointer(image.Metadata.Id),
 		// TODO: this is a hack because CAPO is "broken".
-		FlavorID: &flavorName,
+		FlavorID:   &flavor.Metadata.Id,
+		FlavorName: &flavor.Metadata.Name,
 	}
 
 	if m.Disk != nil {
@@ -249,7 +250,7 @@ func (c *Client) generateControlPlane(ctx context.Context, organizationID, proje
 		FlavorId: &resource.Metadata.Id,
 	}
 
-	machine, err := c.generateMachineGeneric(ctx, organizationID, projectID, options, machineOptions, resource.Metadata.Name)
+	machine, err := c.generateMachineGeneric(ctx, organizationID, projectID, options, machineOptions, resource)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +274,7 @@ func (c *Client) generateWorkloadPools(ctx context.Context, organizationID, proj
 			return nil, err
 		}
 
-		machine, err := c.generateMachineGeneric(ctx, organizationID, projectID, options, &pool.Machine, flavor.Metadata.Name)
+		machine, err := c.generateMachineGeneric(ctx, organizationID, projectID, options, &pool.Machine, flavor)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
As they all live in the same project namespace, they need a unique release name.  Also there's an issue with the cluster GET API returning the flavor name, not the ID. Rather than doing a costly lookup, just cache it in the CRDs.