### PR TITLE
Restore Identity ID on Update

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: v0.2.29
-appVersion: v0.2.29
+version: v0.2.30
+appVersion: v0.2.30
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 


### PR DESCRIPTION
The identity ID is not copied from the current to the updated cluster on update, so when it's deleted we end up with no ID, and thus no clean up.