### PR TITLE
Upgrade Cluster(Manager) Deployment

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: v0.2.30
-appVersion: v0.2.30
+version: v0.2.31
+appVersion: v0.2.31
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -107,11 +107,7 @@ spec:
   tags:
   - infrastructure
   versions:
-  - version: v0.1.11
-    repo: https://unikorn-cloud.github.io/helm-cluster-api
-    chart: cluster-api
-    interface: 1.0.0
-  - version: v0.2.0
+  - version: v0.2.1
     repo: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api
     interface: 1.0.0
@@ -166,7 +162,7 @@ spec:
   tags:
   - infrastructure
   versions:
-  - version: v0.4.3
+  - version: v0.5.0
     repo: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-cluster-openstack
     createNamespace: true

--- a/charts/kubernetes/templates/clustermanagerapplicationbundles.yaml
+++ b/charts/kubernetes/templates/clustermanagerapplicationbundles.yaml
@@ -21,4 +21,4 @@ spec:
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "cluster-api" }}
-      version: v0.2.0
+      version: v0.2.1

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -11,7 +11,7 @@ spec:
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "cluster-openstack" }}
-      version: v0.4.3
+      version: v0.5.0
   - name: cilium
     reference:
       kind: HelmApplication


### PR DESCRIPTION
Pickup the new cluster-openstack definition which uses a common version, just like the CRD, to restore parity.  Also, while here update the resource tags so they better align with audit logs and can be used to cross reference billing and usage data by an external perty more easily. This does, however, mean that eany existing clusters will undergo a rolling upgrade to reconcile the tags, because machine templates are immuatble, seems like an optimization we may be able to fix in future... Finally to save a job, roll out the new CAPI/CAPO releases, because why not?