### PR TITLE
adding the skipPhases option to the cluster definitions, structs and openapi schema

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -155,7 +155,7 @@ metadata:
     unikorn-cloud.org/name: cluster-openstack
   annotations:
     unikorn-cloud.org/description: |-
-      Provides an opinionated Kuberenetes cluster deployment for Cluster API's
+      Provides an opinionated Kubernetes cluster deployment for Cluster API's
       OpenStack plugin.
 spec:
   documentation: https://github.com/unikorn-cloud/helm-cluster-api/
@@ -169,6 +169,9 @@ spec:
     chart: cluster-api-cluster-openstack
     createNamespace: true
     interface: 1.0.0
+    parameters:
+      - name: controlPlane.kubeadmSkipPhases[0]
+        value: addon/kube-proxy
 ---
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: HelmApplication


### PR DESCRIPTION
This is probably missing a load of stuff!

I'm more wanting guidance on this as we need to have a way of implementing the skipProxy bits.

I've been through the testing steps but they look like they are from the old world style of testing all of this stuff! 
Is there any up-to-date guides I can go through to make sure this is fully tested?

Also I'm thinking that, for now, we should surface an option to the customer/user on whether they want cilium and if they do, automatically enable `skipPhase: ["kube-proxy"]`. something like "enable Cilium: recommended by unikorn cloud!".

I appreciate this may be missing a bunch of bits but it's a complex code base and it' my first run at it since the new design :-D 