### PR TITLE
Update Region API

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: v0.2.32
-appVersion: v0.2.32
+version: v0.2.33
+appVersion: v0.2.33
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -162,7 +162,7 @@ spec:
   tags:
   - infrastructure
   versions:
-  - version: v0.5.0
+  - version: v0.5.1
     repo: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-cluster-openstack
     createNamespace: true

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -11,7 +11,7 @@ spec:
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "cluster-openstack" }}
-      version: v0.5.0
+      version: v0.5.1
   - name: cilium
     reference:
       kind: HelmApplication

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/unikorn-cloud/core v0.1.63
 	github.com/unikorn-cloud/identity v0.2.29
-	github.com/unikorn-cloud/region v0.1.24
+	github.com/unikorn-cloud/region v0.1.30
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,8 @@ github.com/unikorn-cloud/core v0.1.63 h1:Jl/xuoGRKESMXhS1+apcaS/1I776agTyT75BGz9
 github.com/unikorn-cloud/core v0.1.63/go.mod h1:JcUIQW3+oiZPUQmOlENw3OCi35IBxPKa+J4MbP3TO7k=
 github.com/unikorn-cloud/identity v0.2.29 h1:kKEJmh6tjjdvZWYdZhyRewG3aHf9wmWwG5C/kb+Rm9A=
 github.com/unikorn-cloud/identity v0.2.29/go.mod h1:ujrL+6kRUrPIk4Z0Yc12A+FDy6L4b2Hgzz6oGZlKfGI=
-github.com/unikorn-cloud/region v0.1.24 h1:95pxAPSV9XO2EIhoUyigrqaouq/16b9A2S7j1T1iJOA=
-github.com/unikorn-cloud/region v0.1.24/go.mod h1:S2rwlo55WfPCbuBxWj8cCg8cQ/qSi3xt3kpgoFkJqNc=
+github.com/unikorn-cloud/region v0.1.30 h1:r5fTsmU9ub1VpYk3cZBUFZjNDaYW8OOtIGPbvxbN++s=
+github.com/unikorn-cloud/region v0.1.30/go.mod h1:S2rwlo55WfPCbuBxWj8cCg8cQ/qSi3xt3kpgoFkJqNc=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
This includes an addition where a server group is provisioned for the identity, we can then consume that and pass it through to CAPO, which was inevitably broken by a new CRD, so we need to include a new chart for that.