### PR TITLE
[NS-837] Bump Cilium to latest and greatest

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -132,7 +132,7 @@ spec:
   - networking
   - security
   versions:
-  - version: 1.15.5
+  - version: 1.16.0
     repo: https://helm.cilium.io
     chart: cilium
     parameters:
@@ -141,6 +141,8 @@ spec:
     - name: hubble.ui.enabled
       value: 'true'
     - name: operator.setNodeTaints
+      value: 'false'
+    - name: envoy.enabled
       value: 'false'
     interface: 1.0.0
 ---

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -16,7 +16,7 @@ spec:
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "cilium" }}
-      version: 1.15.5
+      version: 1.16.0
   - name: openstack-cloud-provider
     reference:
       kind: HelmApplication

--- a/pkg/server/handler/cluster/client.go
+++ b/pkg/server/handler/cluster/client.go
@@ -232,7 +232,7 @@ func (c *Client) applyCloudSpecificConfiguration(ctx context.Context, organizati
 
 	cluster.Annotations[constants.CloudIdentityAnnotation] = identity.Metadata.Id
 
-	// Setup the provider specific stuff, this should be as minial as possible!
+	// Setup the provider specific stuff, this should be as minimal as possible!
 	switch identity.Spec.Type {
 	case regionapi.Openstack:
 		externalNetworks, err := c.getExternalNetworks(ctx, organizationID, regionID)


### PR DESCRIPTION
Upgrade Cilium to 1.16.  Successfully deployed a cluster and confirmed the release version is as expected:

```
% cilium version
cilium-cli: v0.16.14 compiled with go1.22.5 on darwin/arm64
cilium image (default): v1.16.0
cilium image (stable): v1.16.0
```

```
% k get kubernetescluster a7727736-c9b9-40cc-af95-c1878fe3f7c6 -n project-smnv4 -o jsonpath="{.status.conditions[].message}"
Provisioned
```