### PR TITLE
Preserve Defaulted Values

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: v0.2.41
-appVersion: v0.2.41
+version: v0.2.42
+appVersion: v0.2.42
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -147,6 +147,16 @@ func (c *KubernetesCluster) GPUOperatorEnabled() bool {
 	return c.Spec.Features != nil && c.Spec.Features.GPUOperator != nil && *c.Spec.Features.GPUOperator
 }
 
+func (c *KubernetesCluster) GetWorkloadPool(name string) *KubernetesClusterWorkloadPoolsPoolSpec {
+	for i, pool := range c.Spec.WorkloadPools.Pools {
+		if pool.Name == name {
+			return &c.Spec.WorkloadPools.Pools[i]
+		}
+	}
+
+	return nil
+}
+
 func CompareClusterManager(a, b ClusterManager) int {
 	return strings.Compare(a.Name, b.Name)
 }

--- a/pkg/server/handler/cluster/client.go
+++ b/pkg/server/handler/cluster/client.go
@@ -390,7 +390,7 @@ func (c *Client) Update(ctx context.Context, organizationID, projectID, clusterI
 		return err
 	}
 
-	required, err := newGenerator(c.client, c.options, c.region, namespace.Name, organizationID, projectID).generate(ctx, request)
+	required, err := newGenerator(c.client, c.options, c.region, namespace.Name, organizationID, projectID).withExisting(current).generate(ctx, request)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The Kubernetes Server defaults a bunch of fields where we don't really want to expose all that complexity to the end user, but require it in the custom resource e.g. images etc.  Problem is, the defaults change, and that will randomly trigger updates which isn't great.  There are also hard coded values e.g. the control plane replicas, and you as an admin may want to scale that to 5, 7 etc. to support a specific weird workload, and obviously don't want that value reverted on an update. Long story short, if it's defaulted, preserve what's there all ready if we can, otherwise generate from the defaults.