### PR TITLE
Create LB monitor by default, upgrade CCM version

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -165,7 +165,7 @@ spec:
   tags:
   - infrastructure
   versions:
-  - version: 2.30.1
+  - version: 2.31.1
     repo: https://kubernetes.github.io/cloud-provider-openstack
     chart: openstack-cloud-controller-manager
     createNamespace: true
@@ -190,7 +190,7 @@ spec:
   - infrastructure
   - storage
   versions:
-  - version: 2.30.0
+  - version: 2.31.1
     repo: https://kubernetes.github.io/cloud-provider-openstack
     chart: openstack-cinder-csi
     createNamespace: true

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -21,12 +21,12 @@ spec:
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "openstack-cloud-provider" }}
-      version: 2.30.1
+      version: 2.31.1
   - name: openstack-plugin-cinder-csi
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "openstack-plugin-cinder-csi" }}
-      version: 2.30.0
+      version: 2.31.1
   - name: metrics-server
     reference:
       kind: HelmApplication

--- a/pkg/provisioners/helmapplications/openstackcloudprovider/provisioner.go
+++ b/pkg/provisioners/helmapplications/openstackcloudprovider/provisioner.go
@@ -112,6 +112,10 @@ func GenerateCloudConfig(options *kubernetesprovisioners.ClusterOpenstackOptions
 		return "", err
 	}
 
+	if _, err := loadBalancer.NewKey("create-monitor", "true"); err != nil {
+		return "", err
+	}
+
 	blockStorage, err := cloudConfig.NewSection("BlockStorage")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Creating a LoadBalancer Service without this set can result in broken behaviour when externalTrafficPolicy is set to Local, since traffic can be forwarded to nodes in a cluster which are not running the target service in question.

Also update the CCM version to the latest release.

Tested with an existing cluster as well as provisioning afresh.  In the case of the former and where LoadBalancer Services already exist, these are updated in-situ with healthmonitors created per OpenStack LB pool and no downtime.

[NHTA-182]