### PR TITLE
Add More Server Metadata

### DIFF
--- a/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
@@ -282,13 +282,12 @@ func (p *Provisioner) Values(ctx context.Context, version *string) (interface{},
 
 	// These must have parity with what's defined by the API to make
 	// cross referencing between unikorn and openstack logging easier.
-	// TODO: clusterID is not going to cut it moving forward, especially
-	// when baremetal clusters are a thing and we'll need to differentiate
-	// between them.
 	serverMetadata := map[string]interface{}{
+		"cluterKind":     "kubernetes",
 		"clusterID":      cluster.Name,
 		"projectID":      labels[constants.ProjectLabel],
 		"organizationID": labels[constants.OrganizationLabel],
+		"regionID":       cluster.Spec.RegionID,
 	}
 
 	machine, err := p.generateMachineHelmValues(cluster.Spec.ControlPlane, true)


### PR DESCRIPTION
External billing platforms may need additional data to apply costings to a cluster, e.g. the region it's in, as Ceilometer data may not provide a differentiator.  Also address the comment about the cluster type. Just layer this on rather than changing the ID to not upset the applecart too much.