### PR TITLE
Remove Old CRD Fields

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: v0.2.44
-appVersion: v0.2.44
+version: v0.2.45
+appVersion: v0.2.45
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -19,7 +19,6 @@ spec:
   tags:
   - security
   - networking
-  exported: true
   versions:
   - version: v1.14.5
     repo: https://charts.jetstack.io


### PR DESCRIPTION
Some lingering smells from the old times.  Now applications are private to the service running them, there is no need for an exported field, so remove this.