### PR TITLE
Add CP CPU/Memory Limits

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,6 +21,8 @@ linters:
   - goconst
   - perfsprint
   - mnd
+  - exportloopref
+  - execinquery
 linters-settings:
   gci:
     sections:

--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: v0.2.47
-appVersion: v0.2.47
+version: v0.2.48
+appVersion: v0.2.48
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/server/handler/cluster/client.go
+++ b/pkg/server/handler/cluster/client.go
@@ -49,10 +49,12 @@ import (
 )
 
 type Options struct {
-	NodeNetwork    net.IPNet
-	ServiceNetwork net.IPNet
-	PodNetwork     net.IPNet
-	DNSNameservers []net.IP
+	ControlPlaneCPUsMax      int
+	ControlPlaneMemoryMaxGiB int
+	NodeNetwork              net.IPNet
+	ServiceNetwork           net.IPNet
+	PodNetwork               net.IPNet
+	DNSNameservers           []net.IP
 }
 
 func (o *Options) AddFlags(f *pflag.FlagSet) {
@@ -62,6 +64,8 @@ func (o *Options) AddFlags(f *pflag.FlagSet) {
 
 	dnsNameservers := []net.IP{net.ParseIP("8.8.8.8")}
 
+	f.IntVar(&o.ControlPlaneCPUsMax, "control-plane-cpus-max", 8, "Default maximum CPUs for control plane flavor selection")
+	f.IntVar(&o.ControlPlaneMemoryMaxGiB, "control-plane-memory-max-gib", 16, "Default maximum memory for control plane flavor selection")
 	f.IPNetVar(&o.NodeNetwork, "default-node-network", *nodeNetwork, "Default node network to use when creating a cluster")
 	f.IPNetVar(&o.ServiceNetwork, "default-service-network", *serviceNetwork, "Default service network to use when creating a cluster")
 	f.IPNetVar(&o.PodNetwork, "default-pod-network", *podNetwork, "Default pod network to use when creating a cluster")

--- a/pkg/server/handler/cluster/conversion.go
+++ b/pkg/server/handler/cluster/conversion.go
@@ -204,7 +204,23 @@ func (g *generator) defaultControlPlaneFlavor(ctx context.Context, request *open
 
 	// No baremetal flavors, and no GPUs.  Would be very wasteful otherwise!
 	flavors = slices.DeleteFunc(flavors, func(x regionapi.Flavor) bool {
-		return (x.Spec.Baremetal != nil && *x.Spec.Baremetal) || x.Spec.Gpu != nil
+		if x.Spec.Baremetal != nil && *x.Spec.Baremetal {
+			return true
+		}
+
+		if x.Spec.Gpu != nil {
+			return true
+		}
+
+		if x.Spec.Cpus > g.options.ControlPlaneCPUsMax {
+			return true
+		}
+
+		if x.Spec.Memory > g.options.ControlPlaneMemoryMaxGiB {
+			return true
+		}
+
+		return false
 	})
 
 	if len(flavors) == 0 {


### PR DESCRIPTION
Using the max was a quick workaround to undersized control planes and platform instability.  This augments that by capping resource utilization.

Fixes #141