### PR TITLE
Fix Load Balancer Leaks

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: v0.2.54-rc1
-appVersion: v0.2.54-rc1
+version: v0.2.54-rc2
+appVersion: v0.2.54-rc2
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/prometheus/client_golang v1.20.5
 	github.com/spf13/pflag v1.0.5
-	github.com/unikorn-cloud/core v0.1.86
+	github.com/unikorn-cloud/core v0.1.87
 	github.com/unikorn-cloud/identity v0.2.45
 	github.com/unikorn-cloud/region v0.1.47-rc4
 	go.opentelemetry.io/otel v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v0.1.86 h1:U8+V5CcTgWT0tVqM6nxlOqLmLP+43Zu0og3OzSe84aI=
-github.com/unikorn-cloud/core v0.1.86/go.mod h1:wEKzCwAnIyTbo27l++Wl+gK95TAxMsFS3y3jbFB03aw=
+github.com/unikorn-cloud/core v0.1.87 h1:2Yk0tjm+qC31IU7CmhxgXiC/HAtLhKyuw//bpoFEOGg=
+github.com/unikorn-cloud/core v0.1.87/go.mod h1:wEKzCwAnIyTbo27l++Wl+gK95TAxMsFS3y3jbFB03aw=
 github.com/unikorn-cloud/identity v0.2.45 h1:YFmw3uunwdZMuYiimv4lfU6s7iTtYoc22xJqLTrlOVg=
 github.com/unikorn-cloud/identity v0.2.45/go.mod h1:WzNNv05ReDMLfWsOtq53uzhX2GU2nXDw76Bdsf3BPnM=
 github.com/unikorn-cloud/region v0.1.47-rc4 h1:rS5vyND9vqMCib5Vd+IktHB4+erRp/+oWzHO20quqsI=


### PR DESCRIPTION
First problem is deleting the OCCM doesn't delete any load balancers, so they block deletion of the router and thus clusters never deprovision. Seond is that if someone tries to do this manually and don't know what they are doing, then chances are you'll leave a bunch of orphaned resources, namely the most scarce and expensive, the IPv4 address.  This adds a pre-deprovision hook that will get called to delete all load balancers, and yield until there are none left.

Fixes https://github.com/unikorn-cloud/region/issues/81