### PR TITLE
Re-introduce v0.19 of vCluster

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -54,6 +54,15 @@ spec:
       value: 'true'
     - name: controlPlane.statefulSet.persistence.volumeClaim.retentionPolicy
       value: Delete
+  - version: 0.19.5
+    repo: https://charts.loft.sh
+    chart: vcluster
+    release: vcluster
+    parameters:
+    - name: hostpathMapper.enabled
+      value: 'true'
+    - name: autoDeletePersistentVolumeClaims
+      value: 'true'
 ---
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: HelmApplication

--- a/charts/kubernetes/templates/clustermanagerapplicationbundles.yaml
+++ b/charts/kubernetes/templates/clustermanagerapplicationbundles.yaml
@@ -11,6 +11,31 @@ spec:
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "vcluster" }}
+      version: 0.19.5
+  - name: cert-manager
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cert-manager" }}
+      version: v1.14.5
+  - name: cluster-api
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-api" }}
+      version: v0.2.1
+---
+apiVersion: unikorn-cloud.org/v1alpha1
+kind: ClusterManagerApplicationBundle
+metadata:
+  name: cluster-manager-1.1.0
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  version: 1.1.0
+  applications:
+  - name: vcluster
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "vcluster" }}
       version: 0.20.1
   - name: cert-manager
     reference:


### PR DESCRIPTION
Essentially revert 14e70f2, and introduce a new clustermanagerapplicationbundle version so that existing Cluster Managers can still be managed without having to be destroyed.