### PR TITLE
Improve Cilium's IPAM

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: v0.2.58-rc1
-appVersion: v0.2.58-rc1
+version: v0.2.58-rc2
+appVersion: v0.2.58-rc2
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/pkg/provisioners/helmapplications/cilium/provisioner.go
+++ b/pkg/provisioners/helmapplications/cilium/provisioner.go
@@ -84,6 +84,13 @@ func (p *Provisioner) Values(ctx context.Context, _ *string) (interface{}, error
 				"tolerations":  util.ControlPlaneTolerations(),
 			},
 		},
+		"ipam": map[string]interface{}{
+			"operator": map[string]interface{}{
+				"clusterPoolIPv4PodCIDRList": []interface{}{
+					cluster.Spec.Network.PodNetwork.IPNet.String(),
+				},
+			},
+		},
 	}
 
 	return values, nil


### PR DESCRIPTION
Seeingly Cilium totally ignores what is passed to kubeadm for pod addresses, so we need to make some tweaks to allow it to do as it's told.  Now luckily, it appears the range it was hard coded to is 10.0.0.0/8.  Anything that was provisioned prior to v0.2.57 was also 10.0.0.0/8, and anything after was broken :D