### PR TITLE
vCluster: Upgrade to v0.23.0, increase default memory limit

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -54,6 +54,19 @@ spec:
       value: 'true'
     - name: controlPlane.statefulSet.persistence.volumeClaim.retentionPolicy
       value: Delete
+  - version: 0.23.0
+    repo: https://charts.loft.sh
+    chart: vcluster
+    release: vcluster
+    parameters:
+    - name: controlPlane.statefulSet.resources.limits.memory
+      value: 4Gi
+    - name: controlPlane.hostPathMapper.enabled
+      value: 'true'
+    - name: controlPlane.backingStore.database.embedded.enabled
+      value: 'true'
+    - name: controlPlane.statefulSet.persistence.volumeClaim.retentionPolicy
+      value: Delete
 ---
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: HelmApplication

--- a/charts/kubernetes/templates/clustermanagerapplicationbundles.yaml
+++ b/charts/kubernetes/templates/clustermanagerapplicationbundles.yaml
@@ -47,3 +47,28 @@ spec:
       kind: HelmApplication
       name: {{ include "resource.id" "cluster-api" }}
       version: v0.2.2
+---
+apiVersion: unikorn-cloud.org/v1alpha1
+kind: ClusterManagerApplicationBundle
+metadata:
+  name: cluster-manager-1.2.0
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  version: 1.2.0
+  applications:
+  - name: vcluster
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "vcluster" }}
+      version: 0.23.0
+  - name: cert-manager
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cert-manager" }}
+      version: v1.14.5
+  - name: cluster-api
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-api" }}
+      version: v0.2.2


### PR DESCRIPTION
Introduce the latest version of vCluster and also double the default memory limit in order to fix #188.

Tested with provisioning a new clustermanager as well as upgrading an existing one.  In the latter case there's a restart of the clustermanager (as expected) but then all services come back with no impact to managed downstream clusters.