### PR TITLE
Fix Cilium

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: v0.2.60-rc1
-appVersion: v0.2.60-rc1
+version: v0.2.60-rc2
+appVersion: v0.2.60-rc2
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -140,7 +140,7 @@ spec:
     - name: bpf.lbExternalClusterIP
       value: 'true'
     interface: 1.0.0
-  - version: 1.17.1
+  - version: 1.18.0-pre.0
     repo: https://helm.cilium.io
     chart: cilium
     namespace: kube-system

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -71,7 +71,7 @@ spec:
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "cilium" }}
-      version: 1.17.1
+      version: 1.18.0-pre.0
   - name: openstack-cloud-provider
     reference:
       kind: HelmApplication


### PR DESCRIPTION
A bug in the 1.17.1 cilium helm chart prevented Argo from ever getting into a stable state, so bump to 1.18.0-pre.0 to acquire the fix.