### PR TITLE
patch: updating cilium and enabling gateway API

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -140,6 +140,24 @@ spec:
     - name: bpf.lbExternalClusterIP
       value: 'true'
     interface: 1.0.0
+  - version: 1.17.2
+    repo: https://helm.cilium.io
+    chart: cilium
+    namespace: kube-system
+    parameters:
+    - name: hubble.relay.enabled
+      value: 'true'
+    - name: hubble.ui.enabled
+      value: 'true'
+    - name: operator.setNodeTaints
+      value: 'false'
+    - name: envoy.enabled
+      value: 'false'
+    - name: bpf.lbExternalClusterIP
+      value: 'true'
+    - name: gatewayAPI.enabled
+      value: 'true'
+    interface: 1.0.0
   - version: 1.18.0-pre.0
     repo: https://helm.cilium.io
     chart: cilium

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -71,6 +71,61 @@ spec:
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "cilium" }}
+      version: 1.17.2
+  - name: openstack-cloud-provider
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "openstack-cloud-provider" }}
+      version: 2.32.0
+  - name: openstack-plugin-cinder-csi
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "openstack-plugin-cinder-csi" }}
+      version: 2.32.0
+  - name: metrics-server
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "metrics-server" }}
+      version: 3.12.2
+  - name: nvidia-gpu-operator
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "nvidia-gpu-operator" }}
+      version: v23.9.1
+  - name: amd-gpu-operator
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "amd-gpu-operator" }}
+      version: v1.2.0
+  - name: cluster-autoscaler
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-autoscaler" }}
+      version: 9.29.3
+  - name: cluster-autoscaler-openstack
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-autoscaler-openstack" }}
+      version: v0.1.0
+---
+apiVersion: unikorn-cloud.org/v1alpha1
+kind: KubernetesClusterApplicationBundle
+metadata:
+  name: kubernetes-cluster-1.1.0
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  version: 1.1.0
+  applications:
+  - name: cluster-openstack
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-openstack" }}
+      version: v0.5.6
+  - name: cilium
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cilium" }}
       version: 1.18.0-pre.0
   - name: openstack-cloud-provider
     reference:


### PR DESCRIPTION
Updating cilium and enabling GatewayAPI so that we can start making use of the wonderful features it supplied over standard ingress.