### PR TITLE
Upgrade CAPI and Cluster Charts

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: v0.2.62-rc1
-appVersion: v0.2.62-rc1
+version: v0.2.62-rc2
+appVersion: v0.2.62-rc2
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -98,7 +98,7 @@ spec:
     parameters:
     - name: cluster-api-bootstrap-kubeadm.kubeadm_bootstrap_token_ttl
       value: 45m
-  - version: v0.2.3
+  - version: v0.2.4
     repo: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api
     parameters:
@@ -176,7 +176,7 @@ spec:
     parameters:
       - name: controlPlane.kubeadmSkipPhases[0]
         value: addon/kube-proxy
-  - version: v0.5.8
+  - version: v0.6.0
     repo: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api-cluster-openstack
     createNamespace: true

--- a/charts/kubernetes/templates/clustermanagerapplicationbundles.yaml
+++ b/charts/kubernetes/templates/clustermanagerapplicationbundles.yaml
@@ -46,7 +46,7 @@ spec:
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "cluster-api" }}
-      version: v0.2.3
+      version: v0.2.4
 ---
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: ClusterManagerApplicationBundle
@@ -71,4 +71,4 @@ spec:
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "cluster-api" }}
-      version: v0.2.3
+      version: v0.2.4

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -132,7 +132,7 @@ spec:
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "cluster-openstack" }}
-      version: v0.5.8
+      version: v0.6.0
   - name: cilium
     reference:
       kind: HelmApplication


### PR DESCRIPTION
Brings in Kubernetes API resource limits to OOM kill that process if it gets out of whack, and also enables insecure metrics for CAPI/CAPO, which live in a private vcluster, so I'm "fine" with this for now.