### PR TITLE
Fix AMD Operator

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -368,6 +368,10 @@ spec:
       value: v1.2.0
     - name: kmm.controller.manager.image.tag
       value: v1.2.0
+    - name: kmm.controller.manager.env.relatedImageSign
+      value: v1.2.0
+    - name: kmm.controller.manager.env.relatedImageWorker
+      value: v1.2.0
     - name: kmm.webhookServer.webhookServer.image.tag
       value: v1.2.0
 ---


### PR DESCRIPTION
While it deploys, it doesn't actually work as there are some KMM images that get picked up after a deploy dynamically.  While I would like to just release a Helm repo, it's done weird upstream, so we'll have to live with this until we get the proper fix upstreamed or we choose to invest a load more time...

Partially Fixes #214