### PR TITLE
API Error Propagation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.21.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
-	github.com/unikorn-cloud/core v0.1.94-rc2
+	github.com/unikorn-cloud/core v0.1.94-rc3
 	github.com/unikorn-cloud/identity v0.2.62-rc1
 	github.com/unikorn-cloud/region v0.1.53-rc3
 	go.opentelemetry.io/otel v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v0.1.94-rc2 h1:dJmIwm8kSwLBfO8wgHCi7pNn5ZjN2/mOLsgNqF3SaCs=
-github.com/unikorn-cloud/core v0.1.94-rc2/go.mod h1:Q+b87c8ji5MmHwnqLK8qUm26L10nD61OdrgtaGvl2iQ=
+github.com/unikorn-cloud/core v0.1.94-rc3 h1:W3Vpl5gBQGdh2F5/bF/OsDhmbuigJovjUtSyB4Ubh7U=
+github.com/unikorn-cloud/core v0.1.94-rc3/go.mod h1:Q+b87c8ji5MmHwnqLK8qUm26L10nD61OdrgtaGvl2iQ=
 github.com/unikorn-cloud/identity v0.2.62-rc1 h1:ibShb3kmqw9J3afNtLMU2h6n8Xy+pXTjttqrg6qtwX8=
 github.com/unikorn-cloud/identity v0.2.62-rc1/go.mod h1:XrXlcrQ5J+jfUUl7b4PuEbVi6TO13u3XWAZHa9gHTP0=
 github.com/unikorn-cloud/region v0.1.53-rc3 h1:arfjoV9WA8czCTRWL3L7mhqrPohA/Pokx+/0WrGtKQI=

--- a/pkg/provisioners/managers/cluster/provisioner.go
+++ b/pkg/provisioners/managers/cluster/provisioner.go
@@ -29,7 +29,6 @@ import (
 	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	coreclient "github.com/unikorn-cloud/core/pkg/client"
 	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
-	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
 	"github.com/unikorn-cloud/core/pkg/manager"
 	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
 	"github.com/unikorn-cloud/core/pkg/provisioners"
@@ -38,6 +37,7 @@ import (
 	"github.com/unikorn-cloud/core/pkg/provisioners/remotecluster"
 	"github.com/unikorn-cloud/core/pkg/provisioners/serial"
 	"github.com/unikorn-cloud/core/pkg/util"
+	coreapiutils "github.com/unikorn-cloud/core/pkg/util/api"
 	identityclient "github.com/unikorn-cloud/identity/pkg/client"
 	unikornv1 "github.com/unikorn-cloud/kubernetes/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/kubernetes/pkg/constants"
@@ -437,7 +437,7 @@ func (p *Provisioner) getIdentity(ctx context.Context, client regionapi.ClientWi
 	}
 
 	if response.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("%w: identity GET expected 200 got %d", coreerrors.ErrAPIStatus, response.StatusCode())
+		return nil, coreapiutils.ExtractError(response.StatusCode(), response)
 	}
 
 	resource := response.JSON200
@@ -467,7 +467,7 @@ func (p *Provisioner) deleteIdentity(ctx context.Context, client regionapi.Clien
 	// we can delete the cluster, a not found means it's been deleted already
 	// and again can proceed.  The goal here is not to leak resources.
 	if statusCode != http.StatusAccepted && statusCode != http.StatusNotFound {
-		return fmt.Errorf("%w: identity DELETE expected 202,404 got %d", ErrResourceDependency, statusCode)
+		return coreapiutils.ExtractError(response.StatusCode(), response)
 	}
 
 	return nil
@@ -488,7 +488,7 @@ func (p *Provisioner) getNetwork(ctx context.Context, client regionapi.ClientWit
 	}
 
 	if response.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("%w: physical network GET expected 200 got %d", coreerrors.ErrAPIStatus, response.StatusCode())
+		return nil, coreapiutils.ExtractError(response.StatusCode(), response)
 	}
 
 	resource := response.JSON200
@@ -513,7 +513,7 @@ func (p *Provisioner) getExternalNetwork(ctx context.Context, client regionapi.C
 	}
 
 	if response.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("%w: external networks GET expected 200 got %d", coreerrors.ErrAPIStatus, response.StatusCode())
+		return nil, coreapiutils.ExtractError(response.StatusCode(), response)
 	}
 
 	externalNetworks := *response.JSON200

--- a/pkg/server/handler/cluster/client.go
+++ b/pkg/server/handler/cluster/client.go
@@ -32,6 +32,7 @@ import (
 	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
 	"github.com/unikorn-cloud/core/pkg/server/conversion"
 	"github.com/unikorn-cloud/core/pkg/server/errors"
+	coreapiutils "github.com/unikorn-cloud/core/pkg/util/api"
 	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
 	unikornv1 "github.com/unikorn-cloud/kubernetes/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/kubernetes/pkg/openapi"
@@ -53,8 +54,6 @@ import (
 
 var (
 	ErrConsistency = goerrors.New("consistency error")
-
-	ErrAPI = goerrors.New("remote api error")
 )
 
 type Options struct {
@@ -288,7 +287,7 @@ func (c *Client) createAllocation(ctx context.Context, organizationID, projectID
 	}
 
 	if resp.StatusCode() != http.StatusCreated {
-		return nil, fmt.Errorf("%w: unexpected status code %d", ErrAPI, resp.StatusCode())
+		return nil, coreapiutils.ExtractError(resp.StatusCode(), resp)
 	}
 
 	return resp.JSON201, nil
@@ -306,7 +305,7 @@ func (c *Client) updateAllocation(ctx context.Context, organizationID, projectID
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		return fmt.Errorf("%w: unexpected status code %d", ErrAPI, resp.StatusCode())
+		return coreapiutils.ExtractError(resp.StatusCode(), resp)
 	}
 
 	return nil
@@ -319,7 +318,7 @@ func (c *Client) deleteAllocation(ctx context.Context, organizationID, projectID
 	}
 
 	if resp.StatusCode() != http.StatusAccepted {
-		return fmt.Errorf("%w: unexpected status code %d", ErrAPI, resp.StatusCode())
+		return coreapiutils.ExtractError(resp.StatusCode(), resp)
 	}
 
 	return nil
@@ -350,7 +349,7 @@ func (c *Client) createIdentity(ctx context.Context, organizationID, projectID, 
 	}
 
 	if resp.StatusCode() != http.StatusCreated {
-		return nil, errors.OAuth2ServerError("unable to create identity")
+		return nil, errors.OAuth2ServerError("unable to create identity").WithError(coreapiutils.ExtractError(resp.StatusCode(), resp))
 	}
 
 	return resp.JSON201, nil
@@ -388,7 +387,7 @@ func (c *Client) createPhysicalNetworkOpenstack(ctx context.Context, organizatio
 	}
 
 	if resp.StatusCode() != http.StatusCreated {
-		return nil, errors.OAuth2ServerError("unable to create physical network")
+		return nil, errors.OAuth2ServerError("unable to create physical network").WithError(coreapiutils.ExtractError(resp.StatusCode(), resp))
 	}
 
 	return resp.JSON201, nil

--- a/pkg/server/handler/region/region.go
+++ b/pkg/server/handler/region/region.go
@@ -18,16 +18,11 @@ package region
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"net/http"
 	"slices"
 
+	coreapiutils "github.com/unikorn-cloud/core/pkg/util/api"
 	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
-)
-
-var (
-	ErrStatusCode = errors.New("unexpected status code")
 )
 
 // Flavors returns all Kubernetes compatible flavors.
@@ -38,7 +33,7 @@ func Flavors(ctx context.Context, client regionapi.ClientWithResponsesInterface,
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("%w: expected 200, got %d", ErrStatusCode, resp.StatusCode())
+		return nil, coreapiutils.ExtractError(resp.StatusCode(), resp)
 	}
 
 	flavors := *resp.JSON200
@@ -59,7 +54,7 @@ func Images(ctx context.Context, client regionapi.ClientWithResponsesInterface, 
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("%w: expected 200, got %d", ErrStatusCode, resp.StatusCode())
+		return nil, coreapiutils.ExtractError(resp.StatusCode(), resp)
 	}
 
 	images := *resp.JSON200


### PR DESCRIPTION
Allow API errors to be parsed and propagated up the stack to aid in debug, rather than doing super generic error handling.