### PR TITLE
Fix values for AMD GPU Operator KMM image references

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -369,9 +369,9 @@ spec:
     - name: kmm.controller.manager.image.tag
       value: v1.2.0
     - name: kmm.controller.manager.env.relatedImageSign
-      value: v1.2.0
+      value: docker.io/rocm/kernel-module-management-signimage:v1.2.0
     - name: kmm.controller.manager.env.relatedImageWorker
-      value: v1.2.0
+      value: docker.io/rocm/kernel-module-management-worker:v1.2.0
     - name: kmm.webhookServer.webhookServer.image.tag
       value: v1.2.0
 ---


### PR DESCRIPTION
The Helm chart for the kernel module management expects the full image path for these values, and not just the tag.