### PR TITLE
Sync runtimeClasses and real nodes for virtualclusters

### DIFF
--- a/pkg/provisioners/helmapplications/virtualcluster/provisioner.go
+++ b/pkg/provisioners/helmapplications/virtualcluster/provisioner.go
@@ -131,6 +131,18 @@ func (p *Provisioner) Values(ctx context.Context, version unikornv1core.Semantic
 		"statefulSet":  statefulSet,
 	}
 
+	sync := map[string]any{
+		"fromHost": map[string]any{
+			"nodes": map[string]any{
+				"enabled":          true,
+				"clearImageStatus": true,
+			},
+			"runtimeClasses": map[string]any{
+				"enabled": true,
+			},
+		},
+	}
+
 	// Block all network traffic between vclusters and the underlying system,
 	// with the exception of egress traffic to the internet.
 	// TODO: we probably want to enable the metric-server integration, and that
@@ -170,6 +182,7 @@ func (p *Provisioner) Values(ctx context.Context, version unikornv1core.Semantic
 	values := map[string]any{
 		"controlPlane":     controlPlane,
 		"policies":         policies,
+		"sync":             sync,
 		"exportKubeConfig": kubeConfig,
 	}
 


### PR DESCRIPTION
We're allocating dedicated nodes in which the host cluster has additional resources advertised such as `nvidia.com/gpu` and `nvidia.com/mlnxnics`, so we actually want to synchronise the node itself to advertise these to the target cluster's workloads.

Similarly we need to sync host runtimeclasses to facilitate GPU workloads.