### PR TITLE
Bump Cluster Chart

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -191,6 +191,13 @@ spec:
     parameters:
       - name: controlPlane.kubeadmSkipPhases[0]
         value: addon/kube-proxy
+  - version: v0.6.1
+    repo: https://unikorn-cloud.github.io/helm-cluster-api
+    chart: cluster-api-cluster-openstack
+    createNamespace: true
+    parameters:
+      - name: controlPlane.kubeadmSkipPhases[0]
+        value: addon/kube-proxy
 ---
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: HelmApplication

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -177,3 +177,63 @@ spec:
       kind: HelmApplication
       name: {{ include "resource.id" "cluster-autoscaler-openstack" }}
       version: v0.1.0
+---
+apiVersion: unikorn-cloud.org/v1alpha1
+kind: KubernetesClusterApplicationBundle
+metadata:
+  name: kubernetes-cluster-1.2.1
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  version: 1.2.1
+  applications:
+  - name: cluster-openstack
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-openstack" }}
+      version: v0.6.1
+  - name: cilium
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cilium" }}
+      version: 1.18.0-pre.0
+  - name: openstack-cloud-provider
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "openstack-cloud-provider" }}
+      version: 2.32.0
+  - name: openstack-plugin-cinder-csi
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "openstack-plugin-cinder-csi" }}
+      version: 2.32.0
+  - name: metrics-server
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "metrics-server" }}
+      version: 3.12.2
+  - name: nvidia-gpu-operator
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "nvidia-gpu-operator" }}
+      version: v23.9.1
+  - name: cert-manager
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cert-manager" }}
+      version: v1.17.1
+  - name: amd-gpu-operator
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "amd-gpu-operator" }}
+      version: v1.2.0
+  - name: cluster-autoscaler
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-autoscaler" }}
+      version: 9.29.3
+  - name: cluster-autoscaler-openstack
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-autoscaler-openstack" }}
+      version: v0.1.0


### PR DESCRIPTION
Removes the cloud provider flag primarily which is removed in Kubernetes 1.33.  Also includes the ability to do pull through caching.  This obviously triggers a rolling upgrade of the K8S control plane.

Fixes #226