### PR TITLE
Deploy latest Nvidia GPU Operator with defaults

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -160,6 +160,21 @@ spec:
       value: 'false'
     - name: bpf.lbExternalClusterIP
       value: 'true'
+  - version: 1.18.0-pre.2
+    repo: https://helm.cilium.io
+    chart: cilium
+    namespace: kube-system
+    parameters:
+    - name: hubble.relay.enabled
+      value: 'true'
+    - name: hubble.ui.enabled
+      value: 'true'
+    - name: operator.setNodeTaints
+      value: 'false'
+    - name: envoy.enabled
+      value: 'false'
+    - name: bpf.lbExternalClusterIP
+      value: 'true'
 ---
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: HelmApplication
@@ -339,6 +354,10 @@ spec:
       value: 'false'
     - name: vgpuDeviceManager.enabled
       value: 'false'
+  - version: v25.3.0
+    repo: https://helm.ngc.nvidia.com/nvidia
+    chart: gpu-operator
+    namespace: kube-system
 ---
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: HelmApplication

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -237,3 +237,63 @@ spec:
       kind: HelmApplication
       name: {{ include "resource.id" "cluster-autoscaler-openstack" }}
       version: v0.1.0
+---
+apiVersion: unikorn-cloud.org/v1alpha1
+kind: KubernetesClusterApplicationBundle
+metadata:
+  name: kubernetes-cluster-1.2.2
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  version: 1.2.2
+  applications:
+  - name: cluster-openstack
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-openstack" }}
+      version: v0.6.1
+  - name: cilium
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cilium" }}
+      version: 1.18.0-pre.2
+  - name: openstack-cloud-provider
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "openstack-cloud-provider" }}
+      version: 2.32.0
+  - name: openstack-plugin-cinder-csi
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "openstack-plugin-cinder-csi" }}
+      version: 2.32.0
+  - name: metrics-server
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "metrics-server" }}
+      version: 3.12.2
+  - name: nvidia-gpu-operator
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "nvidia-gpu-operator" }}
+      version: v25.3.0
+  - name: cert-manager
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cert-manager" }}
+      version: v1.17.1
+  - name: amd-gpu-operator
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "amd-gpu-operator" }}
+      version: v1.2.0
+  - name: cluster-autoscaler
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-autoscaler" }}
+      version: 9.29.3
+  - name: cluster-autoscaler-openstack
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-autoscaler-openstack" }}
+      version: v0.1.0

--- a/pkg/provisioners/helmapplications/nvidiagpuoperator/provisioner.go
+++ b/pkg/provisioners/helmapplications/nvidiagpuoperator/provisioner.go
@@ -39,8 +39,7 @@ var _ application.ValuesGenerator = &Provisioner{}
 
 // Generate implements the application.Generator interface.
 func (p *Provisioner) Values(ctx context.Context, version unikornv1core.SemanticVersion) (any, error) {
-	// We limit images to those with the driver pre-installed as it's far quicker for UX.
-	// Also the default affinity is broken and prevents scale to zero, also tolerations
+	// The default affinity is broken and prevents scale to zero, also tolerations
 	// don't allow execution using our default taints.
 	// TODO: This includes the node-feature-discovery as a subchart, and doesn't expose
 	// node selectors/tolerations, however, it does scale to zero.


### PR DESCRIPTION
Since our stance on what we bake into our images has changed, this commit introduces a new - the latest - release of the Nvidia GPU Operator with the defaults, which is sensible enough to install drivers etc. automatically.

Bump the Cilium version to the newest v0.18 pre while we're here.