### PR TITLE
Optimize API Calls

### DIFF
--- a/charts/kubernetes/templates/server/clusterrole.yaml
+++ b/charts/kubernetes/templates/server/clusterrole.yaml
@@ -36,3 +36,10 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
-	github.com/unikorn-cloud/core v0.1.95
+	github.com/unikorn-cloud/core v0.1.96-rc1
 	github.com/unikorn-cloud/identity v0.2.63
 	github.com/unikorn-cloud/region v0.1.54
 	go.opentelemetry.io/otel v1.35.0
@@ -33,6 +33,7 @@ require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/brunoga/deep v1.2.4 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-oidc/v3 v3.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/brunoga/deep v1.2.4 h1:Aj9E9oUbE+ccbyh35VC/NHlzzjfIVU69BXu2mt2LmL8=
+github.com/brunoga/deep v1.2.4/go.mod h1:GDV6dnXqn80ezsLSZ5Wlv1PdKAWAO4L5PnKYtv2dgaI=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -173,8 +175,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v0.1.95 h1:i5jyWnleYbFxvniKfneiEeeNL2oCtkJjdGtRJipYH9Y=
-github.com/unikorn-cloud/core v0.1.95/go.mod h1:OdZlqXlkO0EFaThARFYRctKAtsVKimhSZid72OaC43Y=
+github.com/unikorn-cloud/core v0.1.96-rc1 h1:TgSMyHhUWYmWgLXiTWNUsroO3F2LtTJ/k+nEDgDnOAo=
+github.com/unikorn-cloud/core v0.1.96-rc1/go.mod h1:stInT6j9sM9KzDHgNxBtmrdDIAxQuIZI1/TCGo0jNK8=
 github.com/unikorn-cloud/identity v0.2.63 h1:cG3Aa3LmweqOwNtOeq9W29/aoJ4wY0uiulLNzWwn7TY=
 github.com/unikorn-cloud/identity v0.2.63/go.mod h1:xuOIyB4wDAz4+kJfZk2q+8MqGj+9IhVbd0Q38iqBY24=
 github.com/unikorn-cloud/region v0.1.54 h1:orGCMLIMUmSWLOlBBha6q5SgXKAlzFqQJRVhneD4/so=

--- a/pkg/server/handler/identity/region.go
+++ b/pkg/server/handler/identity/region.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024-2025 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"context"
+
+	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
+)
+
+// ClientGetterFunc allows us to lazily instantiate a client only when needed to
+// avoid the TLS handshake and token exchange.
+type ClientGetterFunc func(context.Context) (identityapi.ClientWithResponsesInterface, error)
+
+// Client provides a caching layer for retrieval of region assets, and lazy population.
+type Client struct {
+	clientGetter ClientGetterFunc
+}
+
+// New returns a new client.
+func New(clientGetter ClientGetterFunc) *Client {
+	return &Client{
+		clientGetter: clientGetter,
+	}
+}
+
+// Client returns a client.
+func (c *Client) Client(ctx context.Context) (identityapi.ClientWithResponsesInterface, error) {
+	return c.clientGetter(ctx)
+}

--- a/pkg/server/handler/region/region.go
+++ b/pkg/server/handler/region/region.go
@@ -21,14 +21,20 @@ import (
 	"errors"
 	"net/http"
 	"slices"
+	"time"
 
 	coreapiutils "github.com/unikorn-cloud/core/pkg/util/api"
+	"github.com/unikorn-cloud/core/pkg/util/cache"
 	"github.com/unikorn-cloud/kubernetes/pkg/openapi"
 	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
 )
 
 var (
 	ErrUnhandled = errors.New("unhandled case")
+)
+
+const (
+	defaultCacheSize = 4096
 )
 
 // regionTypeFilter creates a filter for use with DeleteFunc that selects regions
@@ -44,8 +50,64 @@ func regionTypeFilter(t openapi.RegionTypeParameter) (func(regionapi.RegionRead)
 	return nil, ErrUnhandled
 }
 
-// Regions lists all regions.
-func Regions(ctx context.Context, client regionapi.ClientWithResponsesInterface, organizationID string, params openapi.GetApiV1OrganizationsOrganizationIDRegionsParams) ([]regionapi.RegionRead, error) {
+// ClientGetterFunc allows us to lazily instantiate a client only when needed to
+// avoid the TLS handshake and token exchange.
+type ClientGetterFunc func(context.Context) (regionapi.ClientWithResponsesInterface, error)
+
+// Client provides a caching layer for retrieval of region assets, and lazy population.
+type Client struct {
+	clientGetter ClientGetterFunc
+	regionCache  *cache.LRUExpireCache[string, []regionapi.RegionRead]
+	flavorCache  *cache.LRUExpireCache[string, []regionapi.Flavor]
+	imageCache   *cache.LRUExpireCache[string, []regionapi.Image]
+}
+
+// New returns a new client.
+func New(clientGetter ClientGetterFunc) *Client {
+	return &Client{
+		clientGetter: clientGetter,
+		regionCache:  cache.NewLRUExpireCache[string, []regionapi.RegionRead](defaultCacheSize),
+		flavorCache:  cache.NewLRUExpireCache[string, []regionapi.Flavor](defaultCacheSize),
+		imageCache:   cache.NewLRUExpireCache[string, []regionapi.Image](defaultCacheSize),
+	}
+}
+
+// Client returns a client.
+func (c *Client) Client(ctx context.Context) (regionapi.ClientWithResponsesInterface, error) {
+	return c.clientGetter(ctx)
+}
+
+// Get gets a specific region.
+func (c *Client) Get(ctx context.Context, organizationID, regionID string) (*regionapi.RegionDetailRead, error) {
+	client, err := c.clientGetter(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Danger, danger, this returns possible sensitive information that must not
+	// be leaked.  Add the correct API.
+	resp, err := client.GetApiV1OrganizationsOrganizationIDRegionsRegionIDDetailWithResponse(ctx, organizationID, regionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return nil, coreapiutils.ExtractError(resp.StatusCode(), resp)
+	}
+
+	return resp.JSON200, nil
+}
+
+func (c *Client) list(ctx context.Context, organizationID string) ([]regionapi.RegionRead, error) {
+	if regions, ok := c.regionCache.Get(organizationID); ok {
+		return regions, nil
+	}
+
+	client, err := c.clientGetter(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	resp, err := client.GetApiV1OrganizationsOrganizationIDRegionsWithResponse(ctx, organizationID)
 	if err != nil {
 		return nil, err
@@ -57,6 +119,18 @@ func Regions(ctx context.Context, client regionapi.ClientWithResponsesInterface,
 
 	regions := *resp.JSON200
 
+	c.regionCache.Add(organizationID, regions, time.Hour)
+
+	return regions, nil
+}
+
+// List lists all regions.
+func (c *Client) List(ctx context.Context, organizationID string, params openapi.GetApiV1OrganizationsOrganizationIDRegionsParams) ([]regionapi.RegionRead, error) {
+	regions, err := c.list(ctx, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
 	filter, err := regionTypeFilter(params.RegionType)
 	if err != nil {
 		return nil, err
@@ -66,7 +140,18 @@ func Regions(ctx context.Context, client regionapi.ClientWithResponsesInterface,
 }
 
 // Flavors returns all Kubernetes compatible flavors.
-func Flavors(ctx context.Context, client regionapi.ClientWithResponsesInterface, organizationID, regionID string) ([]regionapi.Flavor, error) {
+func (c *Client) Flavors(ctx context.Context, organizationID, regionID string) ([]regionapi.Flavor, error) {
+	cacheKey := organizationID + ":" + regionID
+
+	if flavors, ok := c.flavorCache.Get(cacheKey); ok {
+		return flavors, nil
+	}
+
+	client, err := c.clientGetter(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	resp, err := client.GetApiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsWithResponse(ctx, organizationID, regionID)
 	if err != nil {
 		return nil, err
@@ -83,11 +168,24 @@ func Flavors(ctx context.Context, client regionapi.ClientWithResponsesInterface,
 		return x.Spec.Cpus < 2 || x.Spec.Memory < 2
 	})
 
+	c.flavorCache.Add(cacheKey, flavors, time.Hour)
+
 	return flavors, nil
 }
 
 // Images returns all Kubernetes compatible images.
-func Images(ctx context.Context, client regionapi.ClientWithResponsesInterface, organizationID, regionID string) ([]regionapi.Image, error) {
+func (c *Client) Images(ctx context.Context, organizationID, regionID string) ([]regionapi.Image, error) {
+	cacheKey := organizationID + ":" + regionID
+
+	if images, ok := c.imageCache.Get(cacheKey); ok {
+		return images, nil
+	}
+
+	client, err := c.clientGetter(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	resp, err := client.GetApiV1OrganizationsOrganizationIDRegionsRegionIDImagesWithResponse(ctx, organizationID, regionID)
 	if err != nil {
 		return nil, err
@@ -102,6 +200,8 @@ func Images(ctx context.Context, client regionapi.ClientWithResponsesInterface, 
 	images = slices.DeleteFunc(images, func(x regionapi.Image) bool {
 		return x.Spec.SoftwareVersions == nil || (*x.Spec.SoftwareVersions)["kubernetes"] == ""
 	})
+
+	c.imageCache.Add(cacheKey, images, time.Hour)
 
 	return images, nil
 }

--- a/pkg/server/handler/virtualcluster/conversion.go
+++ b/pkg/server/handler/virtualcluster/conversion.go
@@ -29,7 +29,6 @@ import (
 	unikornv1 "github.com/unikorn-cloud/kubernetes/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/kubernetes/pkg/openapi"
 	"github.com/unikorn-cloud/kubernetes/pkg/server/handler/applicationbundle"
-	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -48,8 +47,6 @@ var (
 type generator struct {
 	// client allows Kubernetes access.
 	client client.Client
-	// region is a client to access regions.
-	region regionapi.ClientWithResponsesInterface
 	// namespace the resource is provisioned in.
 	namespace string
 	// organizationID is the unique organization identifier.
@@ -63,10 +60,9 @@ type generator struct {
 	existing *unikornv1.VirtualKubernetesCluster
 }
 
-func newGenerator(client client.Client, region regionapi.ClientWithResponsesInterface, namespace, organizationID, projectID string) *generator {
+func newGenerator(client client.Client, namespace, organizationID, projectID string) *generator {
 	return &generator{
 		client:         client,
-		region:         region,
 		namespace:      namespace,
 		organizationID: organizationID,
 		projectID:      projectID,


### PR DESCRIPTION
Any handler (regions, clusters) that needed access to either the identity service or the region service would unconditionally create a client, and that would involve TLS handshakes and token exchange.  For things like clusters, they only need to update allocations on create/update/delete, not read, and only need access to flavors and images on create/update, thus there is an implicit penalty for APIs that don't need those clients.  This makes API access to those client lazy, and they will only create a client if necessary.  Secondly, much like the region service, we expect things like regions, flavors and images to be relatively static, so we can put a cache in front of these calls with an hour timeout.

The result is that on the standard "List Kubernetes Clusters" UI view, the API response times are now less that 100ms, down from over 1000ms.