### PR TITLE
Use the same remote namespace in provisioner and server

### DIFF
--- a/pkg/provisioners/managers/virtualcluster/provisioner.go
+++ b/pkg/provisioners/managers/virtualcluster/provisioner.go
@@ -229,6 +229,10 @@ func (r *regionRemote) Config(ctx context.Context) (*clientcmdapi.Config, error)
 	return &rawConfig, nil
 }
 
+func RemoteNamespace(cluster *unikornv1.VirtualKubernetesCluster) string {
+	return "virtualcluster-" + cluster.Name
+}
+
 func (p *Provisioner) getProvisioner(kubeconfig []byte) provisioners.Provisioner {
 	apps := newApplicationReferenceGetter(&p.cluster)
 
@@ -246,7 +250,7 @@ func (p *Provisioner) getProvisioner(kubeconfig []byte) provisioners.Provisioner
 	// stuff needs passing into the provisioner.
 	provisioner := remoteCluster.ProvisionOn(
 		// The namespace gets a prefix so it's easier to distinguish for automation and eyeballs.
-		virtualcluster.New(apps.vCluster, p.options.provisionerOptions).InNamespace("virtualcluster-"+p.cluster.Name),
+		virtualcluster.New(apps.vCluster, p.options.provisionerOptions).InNamespace(RemoteNamespace(&p.cluster)),
 		// The remote gets a prefix so it doesn't collide with other org's virtual cluster remotes.
 		remotecluster.WithPrefix("region-org-"+orgID),
 	)

--- a/pkg/server/handler/virtualcluster/client.go
+++ b/pkg/server/handler/virtualcluster/client.go
@@ -31,6 +31,7 @@ import (
 	unikornv1 "github.com/unikorn-cloud/kubernetes/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/kubernetes/pkg/openapi"
 	"github.com/unikorn-cloud/kubernetes/pkg/provisioners/helmapplications/virtualcluster"
+	provisioner "github.com/unikorn-cloud/kubernetes/pkg/provisioners/managers/virtualcluster"
 	"github.com/unikorn-cloud/kubernetes/pkg/server/handler/common"
 	"github.com/unikorn-cloud/kubernetes/pkg/server/handler/identity"
 	"github.com/unikorn-cloud/kubernetes/pkg/server/handler/region"
@@ -167,7 +168,7 @@ func (c *Client) GetKubeconfig(ctx context.Context, organizationID, projectID, c
 	}
 
 	objectKey := client.ObjectKey{
-		Namespace: cluster.Name,
+		Namespace: provisioner.RemoteNamespace(cluster),
 		Name:      "vc-" + virtualcluster.ReleaseName(cluster),
 	}
 


### PR DESCRIPTION
My previous change in #261 gave a prefix to the namespace that a virtual cluster is deployed to. But the server also uses that namespace, to retrieve the kubeconfig secret for the vcluster.

These relied on coincidence, which I broke. Instead, use a common func to calculate the namespace. This still isn't perfect -- ideally I suppose it would find the ArgoCD application and get the namepace from there. But this change removes the coincidence, at least.