### PR TITLE
chore: bump cert-manager version in kubernetes applicationbundle and added values to configure prometheus metrics.

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -53,6 +53,20 @@ spec:
     parameters:
     - name: crds.enabled
       value: "true"
+  - version: v1.20.1
+    repo: https://charts.jetstack.io
+    chart: cert-manager
+    release: cert-manager
+    namespace: cert-manager
+    createNamespace: true
+    parameters:
+    - name: crds.enabled
+      value: "true"
+    - name: prometheus.enabled
+      value: "true"
+    - name: prometheus.servicemonitor.enabled
+      value: "true"
+
 ---
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: HelmApplication

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -232,7 +232,7 @@ spec:
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "cert-manager" }}
-      version: v1.19.2
+      version: v1.20.1
   - name: amd-gpu-operator
     reference:
       kind: HelmApplication

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -188,3 +188,68 @@ spec:
       kind: HelmApplication
       name: {{ include "resource.id" "gateway-api-crds" }}
       version: v1.3.0
+---
+apiVersion: unikorn-cloud.org/v1alpha1
+kind: KubernetesClusterApplicationBundle
+metadata:
+  name: kubernetes-cluster-1.4.1
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  version: 1.4.1
+  applications:
+  - name: cluster-openstack
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-openstack" }}
+      version: v0.6.1
+  - name: cilium
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cilium" }}
+      version: 1.18.6
+  - name: openstack-cloud-provider
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "openstack-cloud-provider" }}
+      version: 2.32.0
+  - name: openstack-plugin-cinder-csi
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "openstack-plugin-cinder-csi" }}
+      version: 2.32.0
+  - name: metrics-server
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "metrics-server" }}
+      version: 3.12.2
+  - name: nvidia-gpu-operator
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "nvidia-gpu-operator" }}
+      version: v25.10.1
+  - name: cert-manager
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cert-manager" }}
+      version: v1.20.1
+  - name: amd-gpu-operator
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "amd-gpu-operator" }}
+      version: v1.2.0
+  - name: cluster-autoscaler
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-autoscaler" }}
+      version: 9.29.3
+  - name: cluster-autoscaler-openstack
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-autoscaler-openstack" }}
+      version: v0.1.0
+  - name: gateway-api-crds
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "gateway-api-crds" }}
+      version: v1.3.0


### PR DESCRIPTION
bump cert-manager version in kubernetes applicationbundle and added values to configure prometheus metrics. This will allow monitoring cert-manager in uni-deployed clusters.