### PR TITLE
chore: bump cert-manager version in kubernetes applicationbundle and added values to configure prometheus metrics.

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -53,6 +53,20 @@ spec:
     parameters:
     - name: crds.enabled
       value: "true"
+  - version: v1.20.1
+    repo: https://charts.jetstack.io
+    chart: cert-manager
+    release: cert-manager
+    namespace: cert-manager
+    createNamespace: true
+    parameters:
+    - name: crds.enabled
+      value: "true"
+    - name: prometheus.enabled
+      value: "true"
+    - name: prometheus.servicemonitor.enabled
+      value: "true"
+
 ---
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: HelmApplication

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -232,7 +232,7 @@ spec:
     reference:
       kind: HelmApplication
       name: {{ include "resource.id" "cert-manager" }}
-      version: v1.19.2
+      version: v1.20.1
   - name: amd-gpu-operator
     reference:
       kind: HelmApplication


### PR DESCRIPTION
bump cert-manager version in kubernetes applicationbundle and added values to configure prometheus metrics. This will allow monitoring cert-manager in uni-deployed clusters.