### PR TITLE
Remove shared region helper caches for scoped region data

### DIFF
--- a/pkg/server/handler/region/region.go
+++ b/pkg/server/handler/region/region.go
@@ -22,20 +22,14 @@ import (
 	"errors"
 	"net/http"
 	"slices"
-	"time"
 
 	servererrors "github.com/unikorn-cloud/core/pkg/server/errors"
-	"github.com/unikorn-cloud/core/pkg/util/cache"
 	"github.com/unikorn-cloud/kubernetes/pkg/openapi"
 	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
 )
 
 var (
 	ErrUnhandled = errors.New("unhandled case")
-)
-
-const (
-	defaultCacheSize = 4096
 )
 
 // regionTypeFilter creates a filter for use with DeleteFunc that selects regions
@@ -51,12 +45,9 @@ func regionTypeFilter(t openapi.RegionTypeParameter) (func(regionapi.RegionRead)
 	return nil, ErrUnhandled
 }
 
-// Client provides a caching layer for retrieval of region assets, and lazy population.
+// Client provides retrieval of region assets from the region API.
 type Client struct {
-	client      regionapi.ClientWithResponsesInterface
-	regionCache *cache.LRUExpireCache[string, []regionapi.RegionRead]
-	flavorCache *cache.LRUExpireCache[string, []regionapi.Flavor]
-	imageCache  *cache.LRUExpireCache[string, []regionapi.Image]
+	client regionapi.ClientWithResponsesInterface
 }
 
 var _ ClientInterface = &Client{}
@@ -64,10 +55,7 @@ var _ ClientInterface = &Client{}
 // New returns a new client.
 func New(client regionapi.ClientWithResponsesInterface) *Client {
 	return &Client{
-		client:      client,
-		regionCache: cache.NewLRUExpireCache[string, []regionapi.RegionRead](defaultCacheSize),
-		flavorCache: cache.NewLRUExpireCache[string, []regionapi.Flavor](defaultCacheSize),
-		imageCache:  cache.NewLRUExpireCache[string, []regionapi.Image](defaultCacheSize),
+		client: client,
 	}
 }
 
@@ -93,10 +81,6 @@ func (c *Client) Get(ctx context.Context, organizationID, regionID string) (*reg
 }
 
 func (c *Client) list(ctx context.Context, organizationID string) ([]regionapi.RegionRead, error) {
-	if regions, ok := c.regionCache.Get(organizationID); ok {
-		return regions, nil
-	}
-
 	resp, err := c.client.GetApiV1OrganizationsOrganizationIDRegionsWithResponse(ctx, organizationID)
 	if err != nil {
 		return nil, err
@@ -107,8 +91,6 @@ func (c *Client) list(ctx context.Context, organizationID string) ([]regionapi.R
 	}
 
 	regions := *resp.JSON200
-
-	c.regionCache.Add(organizationID, regions, time.Hour)
 
 	return regions, nil
 }
@@ -130,12 +112,6 @@ func (c *Client) List(ctx context.Context, organizationID string, params openapi
 
 // Flavors returns all Kubernetes compatible flavors.
 func (c *Client) Flavors(ctx context.Context, organizationID, regionID string) ([]regionapi.Flavor, error) {
-	cacheKey := organizationID + ":" + regionID
-
-	if flavors, ok := c.flavorCache.Get(cacheKey); ok {
-		return flavors, nil
-	}
-
 	resp, err := c.client.GetApiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsWithResponse(ctx, organizationID, regionID)
 	if err != nil {
 		return nil, err
@@ -152,19 +128,11 @@ func (c *Client) Flavors(ctx context.Context, organizationID, regionID string) (
 		return x.Spec.Cpus < 2 || x.Spec.Memory < 2
 	})
 
-	c.flavorCache.Add(cacheKey, flavors, time.Hour)
-
 	return flavors, nil
 }
 
 // Images returns all Kubernetes compatible images.
 func (c *Client) Images(ctx context.Context, organizationID, regionID string) ([]regionapi.Image, error) {
-	cacheKey := organizationID + ":" + regionID
-
-	if images, ok := c.imageCache.Get(cacheKey); ok {
-		return images, nil
-	}
-
 	resp, err := c.client.GetApiV1OrganizationsOrganizationIDRegionsRegionIDImagesWithResponse(ctx, organizationID, regionID)
 	if err != nil {
 		return nil, err
@@ -179,8 +147,6 @@ func (c *Client) Images(ctx context.Context, organizationID, regionID string) ([
 	images = slices.DeleteFunc(images, func(x regionapi.Image) bool {
 		return x.Spec.SoftwareVersions == nil || (*x.Spec.SoftwareVersions)["kubernetes"] == ""
 	})
-
-	c.imageCache.Add(cacheKey, images, time.Hour)
 
 	return images, nil
 }

--- a/pkg/server/handler/region/region_test.go
+++ b/pkg/server/handler/region/region_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package region_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	kubernetesapi "github.com/unikorn-cloud/kubernetes/pkg/openapi"
+	"github.com/unikorn-cloud/kubernetes/pkg/server/handler/region"
+	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
+)
+
+var errUnexpectedRequestCount = errors.New("unexpected request count")
+
+func TestListDoesNotCacheImpersonatedResponses(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+
+	client, err := newTestClient(func(req *http.Request) (*http.Response, error) {
+		requests++
+
+		switch requests {
+		case 1:
+			return jsonResponse([]map[string]any{
+				{
+					"metadata": map[string]any{"id": "region-1"},
+					"spec":     map[string]any{"type": "kubernetes"},
+				},
+			})
+		case 2:
+			return jsonResponse([]map[string]any{
+				{
+					"metadata": map[string]any{"id": "region-2"},
+					"spec":     map[string]any{"type": "kubernetes"},
+				},
+			})
+		default:
+			t.Fatalf("unexpected request count: %d", requests)
+
+			return nil, errUnexpectedRequestCount
+		}
+	})
+	require.NoError(t, err)
+
+	regions := region.New(client)
+	params := kubernetesapi.GetApiV1OrganizationsOrganizationIDRegionsParams{
+		RegionType: kubernetesapi.Virtual,
+	}
+
+	first, err := regions.List(t.Context(), "org-1", params)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	require.Equal(t, "region-1", first[0].Metadata.Id)
+
+	second, err := regions.List(t.Context(), "org-1", params)
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	require.Equal(t, "region-2", second[0].Metadata.Id)
+	require.Equal(t, 2, requests)
+}
+
+func TestFlavorsDoesNotCacheImpersonatedResponses(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+
+	client, err := newTestClient(func(req *http.Request) (*http.Response, error) {
+		requests++
+
+		switch requests {
+		case 1:
+			return jsonResponse([]map[string]any{
+				{
+					"metadata": map[string]any{"id": "flavor-1"},
+					"spec":     map[string]any{"cpus": 2, "memory": 4},
+				},
+			})
+		case 2:
+			return jsonResponse([]map[string]any{
+				{
+					"metadata": map[string]any{"id": "flavor-2"},
+					"spec":     map[string]any{"cpus": 2, "memory": 4},
+				},
+			})
+		default:
+			t.Fatalf("unexpected request count: %d", requests)
+
+			return nil, errUnexpectedRequestCount
+		}
+	})
+	require.NoError(t, err)
+
+	regions := region.New(client)
+
+	first, err := regions.Flavors(t.Context(), "org-1", "region-1")
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	require.Equal(t, "flavor-1", first[0].Metadata.Id)
+
+	second, err := regions.Flavors(t.Context(), "org-1", "region-1")
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	require.Equal(t, "flavor-2", second[0].Metadata.Id)
+	require.Equal(t, 2, requests)
+}
+
+func TestImagesDoesNotCacheImpersonatedResponses(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+
+	client, err := newTestClient(func(req *http.Request) (*http.Response, error) {
+		requests++
+
+		switch requests {
+		case 1:
+			return jsonResponse([]map[string]any{
+				{
+					"metadata": map[string]any{"id": "image-1"},
+					"spec": map[string]any{
+						"softwareVersions": map[string]any{"kubernetes": "1.31.0"},
+					},
+				},
+			})
+		case 2:
+			return jsonResponse([]map[string]any{
+				{
+					"metadata": map[string]any{"id": "image-2"},
+					"spec": map[string]any{
+						"softwareVersions": map[string]any{"kubernetes": "1.31.1"},
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected request count: %d", requests)
+
+			return nil, errUnexpectedRequestCount
+		}
+	})
+	require.NoError(t, err)
+
+	regions := region.New(client)
+
+	first, err := regions.Images(t.Context(), "org-1", "region-1")
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	require.Equal(t, "image-1", first[0].Metadata.Id)
+
+	second, err := regions.Images(t.Context(), "org-1", "region-1")
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	require.Equal(t, "image-2", second[0].Metadata.Id)
+	require.Equal(t, 2, requests)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newTestClient(fn roundTripFunc) (*regionapi.ClientWithResponses, error) {
+	httpClient := &http.Client{
+		Transport: fn,
+	}
+
+	return regionapi.NewClientWithResponses("http://region.example", regionapi.WithHTTPClient(httpClient))
+}
+
+func jsonResponse(body any) (*http.Response, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body: io.NopCloser(bytes.NewReader(data)),
+	}, nil
+}


### PR DESCRIPTION
The region helper assumed region, flavor, and image reads were effectively static per organization or region, so it cached responses globally by org/region. That assumption no longer holds now that these API calls are resolved under caller impersonation and can return caller-scoped data.

A shared cache can therefore serve data that is valid for one caller but invalid for another. In the worst case, a higher-privilege caller can populate the cache and a lower-privilege caller can later reuse those results, turning an authorization bug into cross-user data leakage and potential privilege escalation.

Remove the shared caches so region authorization and visibility are evaluated on every request. The performance tradeoff is acceptable: the compute service already follows the same uncached model and has not shown problematic degradation in practice. If caching is needed, the correct boundary is the region service, where request context and authorization are owned consistently, rather than duplicating cache behaviour in downstream services and recreating this class of bug in downstream consumers.
