### PR TITLE
Bump identity to v1.16.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/unikorn-cloud/core v1.14.0-rc1.0.20260415101853-f48436d47c7a
-	github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260415125328-4be4f9714606
+	github.com/unikorn-cloud/identity v1.16.1
 	github.com/unikorn-cloud/region v1.15.0-pre1.0.20260415130724-acebc1bbab87
 	go.uber.org/mock v0.5.2
 	gopkg.in/ini.v1 v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/unikorn-cloud/core v1.14.0-rc1.0.20260415101853-f48436d47c7a h1:0zxJ8
 github.com/unikorn-cloud/core v1.14.0-rc1.0.20260415101853-f48436d47c7a/go.mod h1:xbPBXjhgOp2O0HSx+utFwmVkxheAHp7z+h1RCyBEswE=
 github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260415125328-4be4f9714606 h1:KdObcFJmbzJL05RiMvWWaDZNuOB1OFNp70i0jjNNL30=
 github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260415125328-4be4f9714606/go.mod h1:N5F9BXYWcv5VKNgKo/NRWII+A4x+KGiDlU7o1c/rU54=
+github.com/unikorn-cloud/identity v1.16.1 h1:YJc3ONk5OJdNO7paHTnvPhXnJlvfBuP4gS+swckM4RI=
+github.com/unikorn-cloud/identity v1.16.1/go.mod h1:N5F9BXYWcv5VKNgKo/NRWII+A4x+KGiDlU7o1c/rU54=
 github.com/unikorn-cloud/region v1.15.0-pre1.0.20260415130724-acebc1bbab87 h1:MfnJlMDp9eKydTGS+RUgUULAg3rQ3U0wlTZ1Pm4gXQY=
 github.com/unikorn-cloud/region v1.15.0-pre1.0.20260415130724-acebc1bbab87/go.mod h1:+2Kpdz05J7rR1omkGbNDx/U72iE1ESyk6wIcToZDTMs=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=


### PR DESCRIPTION
Update the identity dependency to the latest release, without which this service is non-functional with the following error returned from identity:

```
error='invalid impersonated principal type: ""'
```