### PR TITLE
chore: version v1.16.2

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: 1.16.1
-appVersion: 1.16.1
+version: 1.16.2
+appVersion: 1.16.2
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 


### PR DESCRIPTION
Release v1.16.2.

Cuts a new release tag so the identity v1.17.1 bump (already merged to main) can be built into a deployable image + Helm chart and pinned in k8s-deploy-unikorn.

Chart-only change: bumps `version` + `appVersion` to 1.16.2. Tag v1.16.2 will be pushed on the merge commit once this lands.