### PR TITLE
Update image selection logic to account for architecture

### DIFF
--- a/pkg/server/handler/cluster/conversion.go
+++ b/pkg/server/handler/cluster/conversion.go
@@ -290,21 +290,42 @@ func (g *generator) defaultControlPlaneFlavor(ctx context.Context, request *open
 	return &flavors[len(flavors)-1], nil
 }
 
+// flavorByID returns the flavor with the given ID from the region.
+func (g *generator) flavorByID(ctx context.Context, request *openapi.KubernetesClusterWrite, id string) (*regionapi.Flavor, error) {
+	flavors, err := g.region.Flavors(ctx, g.organizationID, request.Spec.RegionId)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to list flavors", err)
+	}
+
+	index := slices.IndexFunc(flavors, func(x regionapi.Flavor) bool {
+		return x.Metadata.Id == id
+	})
+
+	if index < 0 {
+		return nil, fmt.Errorf("%w: flavor %s not found", coreerrors.ErrConsistency, id)
+	}
+
+	return &flavors[index], nil
+}
+
 // defaultImage returns a default image for either control planes or workload pools
-// based on the specified Kubernetes version.
-func (g *generator) defaultImage(ctx context.Context, request *openapi.KubernetesClusterWrite) (*regionapi.Image, error) {
+// based on the specified Kubernetes version and CPU architecture.
+func (g *generator) defaultImage(ctx context.Context, request *openapi.KubernetesClusterWrite, arch regionapi.Architecture) (*regionapi.Image, error) {
 	images, err := g.region.Images(ctx, g.organizationID, request.Spec.RegionId)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to list images", err)
 	}
 
-	// Only get the version asked for.
 	images = slices.DeleteFunc(images, func(x regionapi.Image) bool {
 		if x.Spec.SoftwareVersions == nil {
 			return true
 		}
 
-		return (*x.Spec.SoftwareVersions)["kubernetes"] != request.Spec.Version
+		if (*x.Spec.SoftwareVersions)["kubernetes"] != request.Spec.Version {
+			return true
+		}
+
+		return x.Spec.Architecture != arch
 	})
 
 	if len(images) == 0 {
@@ -315,13 +336,13 @@ func (g *generator) defaultImage(ctx context.Context, request *openapi.Kubernete
 }
 
 // imageID returns an existing image ID if one is available, and the Kubernetes version
-// has not changed, otherwise the newest image for the given version.
-func (g *generator) imageID(ctx context.Context, request *openapi.KubernetesClusterWrite, imageID *string) (*string, error) {
+// has not changed, otherwise the newest image for the given version and architecture.
+func (g *generator) imageID(ctx context.Context, request *openapi.KubernetesClusterWrite, imageID *string, arch regionapi.Architecture) (*string, error) {
 	if imageID != nil && request.Spec.Version == g.existing.Spec.Version.Original() {
 		return imageID, nil
 	}
 
-	image, err := g.defaultImage(ctx, request)
+	image, err := g.defaultImage(ctx, request, arch)
 	if err != nil {
 		return nil, err
 	}
@@ -422,7 +443,12 @@ func (g *generator) generateMachineGeneric(ctx context.Context, request *openapi
 		FlavorID: *m.FlavorId,
 	}
 
-	imageID, err := g.imageID(ctx, request, imageID)
+	flavor, err := g.flavorByID(ctx, request, *m.FlavorId)
+	if err != nil {
+		return nil, err
+	}
+
+	imageID, err = g.imageID(ctx, request, imageID, flavor.Spec.Architecture)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/handler/cluster/conversion_test.go
+++ b/pkg/server/handler/cluster/conversion_test.go
@@ -97,15 +97,16 @@ func applicationBundleFixture(t *testing.T, version string, namespace, name stri
 	}
 }
 
-func flavorFixture(id string, cpus, memory, disk int) *regionapi.Flavor {
+func flavorFixture(id string, cpus, memory, disk int, arch regionapi.Architecture) *regionapi.Flavor {
 	return &regionapi.Flavor{
 		Metadata: coreapi.StaticResourceMetadata{
 			Id: id,
 		},
 		Spec: regionapi.FlavorSpec{
-			Cpus:   cpus,
-			Memory: memory,
-			Disk:   disk,
+			Cpus:         cpus,
+			Memory:       memory,
+			Disk:         disk,
+			Architecture: arch,
 		},
 	}
 }
@@ -122,18 +123,19 @@ func flavorFixtureList(in ...*regionapi.Flavor) regionapi.Flavors {
 
 func flavorFixtures() regionapi.Flavors {
 	return flavorFixtureList(
-		flavorFixture(flavorID1, 2, 2, 10),
-		flavorFixture(flavorID2, 4, 4, 20),
+		flavorFixture(flavorID1, 2, 2, 10, regionapi.ArchitectureX8664),
+		flavorFixture(flavorID2, 4, 4, 20, regionapi.ArchitectureX8664),
 	)
 }
 
-func imageFixture(id, version string) *regionapi.Image {
+func imageFixture(id, version string, arch regionapi.Architecture) *regionapi.Image {
 	return &regionapi.Image{
 		Metadata: coreapi.StaticResourceMetadata{
 			Id: id,
 		},
 		Spec: regionapi.ImageSpec{
-			SizeGiB: 10,
+			SizeGiB:      10,
+			Architecture: arch,
 			SoftwareVersions: &regionapi.SoftwareVersions{
 				"kubernetes": version,
 			},
@@ -153,9 +155,9 @@ func imageFixtureList(in ...*regionapi.Image) regionapi.Images {
 
 func imageFixtures() regionapi.Images {
 	return imageFixtureList(
-		imageFixture(imageID1, kubernetesVersion1),
-		imageFixture(imageID2, kubernetesVersion2),
-		imageFixture(imageID3, kubernetesVersion3),
+		imageFixture(imageID1, kubernetesVersion1, regionapi.ArchitectureX8664),
+		imageFixture(imageID2, kubernetesVersion2, regionapi.ArchitectureX8664),
+		imageFixture(imageID3, kubernetesVersion3, regionapi.ArchitectureX8664),
 	)
 }
 
@@ -512,6 +514,58 @@ func TestClusterUpdatePreservesHardwareEnablementWhenFeatureFieldOmitted(t *test
 	require.NoError(t, err)
 	require.NotNil(t, cluster.Spec.Features)
 	require.False(t, cluster.Spec.Features.GPUOperator)
+}
+
+// TestClusterGenerateSelectsImageMatchingFlavorArchitecture checks that when a region
+// exposes images for multiple architectures, the image selected matches the flavor's
+// architecture rather than returning an arbitrary first match.
+func TestClusterGenerateSelectsImageMatchingFlavorArchitecture(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	ctx = fixtures.HandlerContextFixture(ctx, fixtures.WithOrganization)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c := newClient(t)
+
+	appclient := applicationbundle.NewClient(c, defaultNamespace)
+
+	// flavorID1 is arm64; flavorID2 is x86_64.
+	mixedFlavors := flavorFixtureList(
+		flavorFixture(flavorID1, 2, 2, 10, regionapi.ArchitectureAarch64),
+		flavorFixture(flavorID2, 4, 4, 20, regionapi.ArchitectureX8664),
+	)
+
+	// Two images for the same k8s version: one per architecture.
+	mixedImages := imageFixtureList(
+		imageFixture(imageID1, kubernetesVersion2, regionapi.ArchitectureX8664),
+		imageFixture(imageID2, kubernetesVersion2, regionapi.ArchitectureAarch64),
+	)
+
+	r := region.NewMockClientInterface(ctrl)
+	r.EXPECT().Flavors(ctx, organizationID, regionID).AnyTimes().Return(mixedFlavors, nil)
+	r.EXPECT().Images(ctx, organizationID, regionID).AnyTimes().Return(mixedImages, nil)
+
+	// Request uses flavorID1 (arm64) for the workload pool.
+	request := clusterRequestFixture(kubernetesVersion2)
+
+	g := cluster.NewGenerator(c, newGeneratorOptions(), r, defaultNamespace, organizationID, projectID)
+
+	result, err := cluster.Generate(ctx, g, appclient, clusterManagerFixture(), request)
+	require.NoError(t, err)
+
+	// Control plane auto-selects a flavor; with the size constraints (CPUs ≤ 2, memory ≤ 10)
+	// flavorID1 (arm64, 2 CPU / 2 GiB) is the only candidate, so the control plane image
+	// must be the arm64 one.
+	require.Equal(t, imageID2, result.Spec.ControlPlane.ImageID)
+
+	// The workload pool explicitly uses flavorID1 (arm64) so it must also get imageID2.
+	require.Len(t, result.Spec.WorkloadPools.Pools, 1)
+	require.Equal(t, imageID2, result.Spec.WorkloadPools.Pools[0].ImageID)
 }
 
 // TestClusterUpdateAppliesExplicitHardwareEnablementSetting checks that an explicit


### PR DESCRIPTION
The goal here is to support clusters that contain a mix of ISAs, i.e x86 and arm64.  Right now we just select images based off specified version, which will result in OpenStack refusing to boot when the selected image doesn't match the target ISA.

This change updates the logic to filter based on architecture and then thread into the existing image selection process