### PR TITLE
feat: gate cluster provisioning on image readiness

### DIFF
--- a/pkg/provisioners/managers/cluster/provisioner.go
+++ b/pkg/provisioners/managers/cluster/provisioner.go
@@ -60,6 +60,8 @@ import (
 	regionclient "github.com/unikorn-cloud/region/pkg/client"
 	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
 
+	"k8s.io/utils/ptr"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -483,6 +485,73 @@ func (p *Provisioner) getFlavors(ctx context.Context, client regionapi.ClientWit
 	return flavors, nil
 }
 
+// clusterImageIDs returns the set of distinct image IDs referenced by the cluster's
+// control plane and workload pools.
+func (p *Provisioner) clusterImageIDs() []string {
+	ids := []string{p.cluster.Spec.ControlPlane.ImageID}
+
+	for i := range p.cluster.Spec.WorkloadPools.Pools {
+		ids = append(ids, p.cluster.Spec.WorkloadPools.Pools[i].ImageID)
+	}
+
+	slices.Sort(ids)
+
+	return slices.Compact(ids)
+}
+
+// imagesReady gates provisioning on the readiness of every image referenced by the
+// cluster.  Image selection happens at the API layer and may pick an image that is
+// still uploading, so we yield here until it is ready rather than handing a non-ready
+// image to Cluster API (which would surface a transient OpenStack error).
+//
+// An image that is failed or absent from the listing is a terminal error.  This runs
+// on every reconcile, so retiring or deleting an image that a cluster still references
+// will flip that cluster into an error state: this is intentional, as such a cluster
+// can no longer safely scale out or rebuild nodes and operators should be told.
+func (p *Provisioner) imagesReady(ctx context.Context, client regionapi.ClientWithResponsesInterface) error {
+	log := log.FromContext(ctx)
+
+	organizationID := p.cluster.Labels[coreconstants.OrganizationLabel]
+
+	params := &regionapi.GetApiV2RegionsRegionIDImagesParams{
+		OrganizationID: &regionapi.OrganizationIDQueryParameter{organizationID},
+		Scope:          ptr.To(regionapi.GetApiV2RegionsRegionIDImagesParamsScopeAvailable),
+	}
+
+	resp, err := client.GetApiV2RegionsRegionIDImagesWithResponse(ctx, p.cluster.Spec.RegionID, params)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return servererrors.PropagateError(resp.HTTPResponse, resp)
+	}
+
+	states := map[string]regionapi.ImageState{}
+
+	for _, image := range *resp.JSON200 {
+		states[image.Metadata.Id] = image.Status.State
+	}
+
+	for _, id := range p.clusterImageIDs() {
+		// A missing image has the zero-value state, which falls through to the
+		// terminal default along with failed.
+		//nolint:exhaustive
+		switch states[id] {
+		case regionapi.ImageStateReady:
+			continue
+		case regionapi.ImageStateCreating, regionapi.ImageStatePending:
+			log.Info("waiting for image to become ready", "imageID", id)
+
+			return provisioners.ErrYield
+		default:
+			return fmt.Errorf("%w: image %s is not available", ErrResourceDependency, id)
+		}
+	}
+
+	return nil
+}
+
 func (p *Provisioner) getIdentity(ctx context.Context, client regionapi.ClientWithResponsesInterface) (*regionapi.IdentityRead, error) {
 	log := log.FromContext(ctx)
 
@@ -590,6 +659,10 @@ func (p *Provisioner) identityOptions(ctx context.Context, client regionapi.Clie
 
 	externalNetwork, err := p.getExternalNetwork(ctx, client)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := p.imagesReady(ctx, client); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/handler/region/region.go
+++ b/pkg/server/handler/region/region.go
@@ -26,6 +26,8 @@ import (
 	servererrors "github.com/unikorn-cloud/core/pkg/server/errors"
 	"github.com/unikorn-cloud/kubernetes/pkg/openapi"
 	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
+
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -132,8 +134,24 @@ func (c *Client) Flavors(ctx context.Context, organizationID, regionID string) (
 }
 
 // Images returns all Kubernetes compatible images.
+//
+// This uses the region v2 images API, which (unlike the deprecated v1 API) does not
+// filter by readiness server side.  We deliberately include images that are not yet
+// ready (e.g. still uploading) so that a freshly created image is selectable
+// immediately; the cluster provisioner gates on readiness and holds provisioning
+// until the selected image becomes ready.
 func (c *Client) Images(ctx context.Context, organizationID, regionID string) ([]regionapi.Image, error) {
-	resp, err := c.client.GetApiV1OrganizationsOrganizationIDRegionsRegionIDImagesWithResponse(ctx, organizationID, regionID)
+	params := &regionapi.GetApiV2RegionsRegionIDImagesParams{
+		OrganizationID: &regionapi.OrganizationIDQueryParameter{organizationID},
+		Scope:          ptr.To(regionapi.GetApiV2RegionsRegionIDImagesParamsScopeAvailable),
+		Status: &regionapi.ImageStatusQueryParameter{
+			regionapi.ImageStateReady,
+			regionapi.ImageStatePending,
+			regionapi.ImageStateCreating,
+		},
+	}
+
+	resp, err := c.client.GetApiV2RegionsRegionIDImagesWithResponse(ctx, regionID, params)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Business justification
----------------------
Customers reported that images do not appear "instantly" (INST-881). The
root cause is the region v1 images API, which filters images by readiness
server side: a freshly uploaded image stays invisible until its data has
finished uploading. Kubernetes builds its curated image set from that same
v1 API, so a newly published image cannot be used for a cluster until it is
fully ready, and v1 is now deprecated (x-hidden) in favour of v2.

UX-driven implementation decisions
----------------------------------
The product expectation is that a new image is usable immediately and that
the platform "just works" rather than erroring. Three decisions follow from
that:

  * List images via region v2 including not-yet-ready images (ready,
    pending, creating). This makes a new image selectable the moment it is
    created, which is what users expect. Kubernetes selects images
    automatically (there is no user-facing image field), so without this an
    upload of a newer image would either be ignored in favour of an older
    one or fail outright with "unable to select an image".

  * Because selection may now pick an image that is still uploading, the
    cluster provisioner gates on readiness: it yields (staying in the
    benign Provisioning state) until every referenced image is ready,
    rather than handing a non-ready image to Cluster API and surfacing a
    scary, transient OpenStack error. Gating in our reconcile loop means
    correctness does not depend on how Nova reacts to a non-active image.

  * A failed or absent image is a terminal error. The gate runs on every
    reconcile, so retiring or deleting an image that a cluster still
    references will flip that cluster into an error state. This is
    intentional: such a cluster can no longer safely scale out or rebuild
    nodes, and surfacing that at reconcile time is far better than letting
    it fail silently at the next scale event.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
