### PR TITLE
fix: enable NVIDIA driver RDMA by region

### DIFF
--- a/charts/kubernetes/templates/cluster-controller/deployment.yaml
+++ b/charts/kubernetes/templates/cluster-controller/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         {{- include "unikorn.region.flags" . | nindent 8 }}
         {{- include "unikorn.otlp.flags" . | nindent 8 }}
         {{- include "unikorn.mtls.flags" . | nindent 8 }}
+        {{- with .Values.clusterController.nvidiaRDMAEnabledRegionIDs }}
+        - --nvidia-rdma-enabled-region-ids={{ join "," . }}
+        {{- end }}
         ports:
         - name: prometheus
           containerPort: 8080

--- a/charts/kubernetes/values.yaml
+++ b/charts/kubernetes/values.yaml
@@ -28,6 +28,8 @@ clusterManagerController:
 clusterController:
   # Allows override of the global default image.
   image:
+  # Region IDs where the NVIDIA GPU driver should enable RDMA integration.
+  nvidiaRDMAEnabledRegionIDs: []
   # Allows resource limits to be set.
   resources:
     limits:

--- a/pkg/provisioners/helmapplications/nvidiahwe/export_test.go
+++ b/pkg/provisioners/helmapplications/nvidiahwe/export_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvidiahwe
+
+import "github.com/unikorn-cloud/core/pkg/provisioners/application"
+
+func NewValuesGenerator(options ProvisionerOptions) application.ValuesGenerator {
+	return &Provisioner{
+		options: options,
+	}
+}

--- a/pkg/provisioners/helmapplications/nvidiahwe/provisioner.go
+++ b/pkg/provisioners/helmapplications/nvidiahwe/provisioner.go
@@ -24,14 +24,23 @@ import (
 	"github.com/unikorn-cloud/core/pkg/provisioners/util"
 )
 
+// ProvisionerOptions define cluster-specific NVIDIA hardware enablement behavior.
+type ProvisionerOptions struct {
+	RDMAEnabled bool
+}
+
 // New returns a new initialized provisioner object.
-func New(getApplication application.GetterFunc) *application.Provisioner {
-	p := &Provisioner{}
+func New(getApplication application.GetterFunc, options ProvisionerOptions) *application.Provisioner {
+	p := &Provisioner{
+		options: options,
+	}
 
 	return application.New(getApplication).WithGenerator(p)
 }
 
-type Provisioner struct{}
+type Provisioner struct {
+	options ProvisionerOptions
+}
 
 // Ensure the Provisioner interface is implemented.
 var _ application.ValuesGenerator = &Provisioner{}
@@ -47,11 +56,18 @@ func (p *Provisioner) Values(ctx context.Context, version unikornv1core.Semantic
 				"tolerations": util.ControlPlaneTolerations(),
 			},
 		},
-		// The GPU operator Deployment itself needs to be pinned to control-plane
-		// nodes and tolerate their taints, consistent with the standalone
-		// nvidia-gpu-operator provisioner.  Daemonsets already use operator:Exists
-		// tolerations in the chart defaults so those require no override.
 		"gpu-operator": map[string]any{
+			// RDMA integration allows the GPU driver to consume the OFED stack
+			// supplied by the NVIDIA Network Operator.
+			"driver": map[string]any{
+				"rdma": map[string]any{
+					"enabled": p.options.RDMAEnabled,
+				},
+			},
+			// The GPU operator Deployment itself needs to be pinned to control-plane
+			// nodes and tolerate their taints, consistent with the standalone
+			// nvidia-gpu-operator provisioner.  Daemonsets already use operator:Exists
+			// tolerations in the chart defaults so those require no override.
 			"operator": map[string]any{
 				"affinity": map[string]any{
 					"nodeAffinity": map[string]any{

--- a/pkg/provisioners/helmapplications/nvidiahwe/provisioner_test.go
+++ b/pkg/provisioners/helmapplications/nvidiahwe/provisioner_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvidiahwe_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/kubernetes/pkg/provisioners/helmapplications/nvidiahwe"
+)
+
+func TestValuesDriverRDMA(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		enabled  bool
+		expected bool
+	}{
+		{
+			name:     "disabled",
+			expected: false,
+		},
+		{
+			name:     "enabled",
+			enabled:  true,
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			generator := nvidiahwe.NewValuesGenerator(nvidiahwe.ProvisionerOptions{
+				RDMAEnabled: test.enabled,
+			})
+
+			values, err := generator.Values(t.Context(), unikornv1core.SemanticVersion{})
+			require.NoError(t, err)
+
+			valueMap, ok := values.(map[string]any)
+			require.True(t, ok)
+
+			gpuOperator, ok := valueMap["gpu-operator"].(map[string]any)
+			require.True(t, ok)
+
+			driver, ok := gpuOperator["driver"].(map[string]any)
+			require.True(t, ok)
+
+			rdma, ok := driver["rdma"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, test.expected, rdma["enabled"])
+		})
+	}
+}

--- a/pkg/provisioners/managers/cluster/export_test.go
+++ b/pkg/provisioners/managers/cluster/export_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+func NvidiaRDMAEnabled(options *Options, regionID string) bool {
+	return options.nvidiaRDMAEnabled(regionID)
+}

--- a/pkg/provisioners/managers/cluster/provisioner.go
+++ b/pkg/provisioners/managers/cluster/provisioner.go
@@ -191,6 +191,9 @@ func (a *ApplicationReferenceGetter) nvidiaHardwareEnablement(ctx context.Contex
 type Options struct {
 	// identityOptions allow the identity host and CA to be set.
 	identityOptions *identityclient.Options
+	// nvidiaRDMAEnabledRegionIDs identifies regions whose NVIDIA GPU driver
+	// requires RDMA integration.
+	nvidiaRDMAEnabledRegionIDs []string
 	// regionOptions allows the region host and CA to be set.
 	regionOptions *regionclient.Options
 	// clientOptions give access to client certificate information as
@@ -212,6 +215,11 @@ func (o *Options) AddFlags(f *pflag.FlagSet) {
 	o.identityOptions.AddFlags(f)
 	o.regionOptions.AddFlags(f)
 	o.clientOptions.AddFlags(f)
+	f.StringSliceVar(&o.nvidiaRDMAEnabledRegionIDs, "nvidia-rdma-enabled-region-ids", nil, "Region IDs where the NVIDIA GPU driver enables RDMA integration")
+}
+
+func (o *Options) nvidiaRDMAEnabled(regionID string) bool {
+	return slices.Contains(o.nvidiaRDMAEnabledRegionIDs, regionID)
 }
 
 // Provisioner encapsulates control plane provisioning.
@@ -381,7 +389,9 @@ func (p *Provisioner) getProvisioner(ctx context.Context, options *kubernetespro
 	addOnsApplications = append(addOnsApplications,
 		conditional.New("nvidia-hardware-enablement",
 			func() bool { return p.cluster.GPUOperatorEnabled() && provisionerOptions.gpuVendorNvidia },
-			nvidiahwe.New(apps.nvidiaHardwareEnablement),
+			nvidiahwe.New(apps.nvidiaHardwareEnablement, nvidiahwe.ProvisionerOptions{
+				RDMAEnabled: p.options.nvidiaRDMAEnabled(p.cluster.Spec.RegionID),
+			}),
 		),
 	)
 

--- a/pkg/provisioners/managers/cluster/provisioner_test.go
+++ b/pkg/provisioners/managers/cluster/provisioner_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster_test
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/kubernetes/pkg/provisioners/managers/cluster"
+)
+
+const (
+	rdmaRegionID  = "7843c0aa-a314-4b12-a6a0-18be0ba47222"
+	otherRegionID = "ce550082-aa4f-49f1-95c1-fec9978afceb"
+)
+
+func TestNvidiaRDMAEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		args     []string
+		regionID string
+		expected bool
+	}{
+		{
+			name:     "empty allowlist",
+			regionID: rdmaRegionID,
+			expected: false,
+		},
+		{
+			name:     "matching region",
+			args:     []string{"--nvidia-rdma-enabled-region-ids=" + rdmaRegionID + "," + otherRegionID},
+			regionID: otherRegionID,
+			expected: true,
+		},
+		{
+			name:     "non-matching region",
+			args:     []string{"--nvidia-rdma-enabled-region-ids=" + rdmaRegionID},
+			regionID: otherRegionID,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			options := &cluster.Options{}
+			flags := pflag.NewFlagSet(t.Name(), pflag.ContinueOnError)
+			options.AddFlags(flags)
+			require.NoError(t, flags.Parse(test.args))
+
+			require.Equal(t, test.expected, cluster.NvidiaRDMAEnabled(options, test.regionID))
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- add a cluster-controller allowlist for regions that require NVIDIA driver RDMA integration
- pass the per-cluster decision into the managed NVIDIA HWE Helm values
- keep RDMA disabled by default and add focused unit and render coverage

## Why

On a clean GPU node join, the Network Operator can replace the host OFED/UMAD devices after the GPU driver container has started. The fabric manager can then lose its management device and remain non-operational. Enabling the GPU Operator's existing `driver.rdma.enabled` integration avoids that startup-ordering problem for affected regions.

The setting is deliberately region-scoped because current regions are hardware-homogeneous and unaffected regions should retain the existing default.

## User impact

Deployment operators can set:

```yaml
clusterController:
  nvidiaRDMAEnabledRegionIDs:
    - <region-uuid>
```

Clusters in listed regions receive `gpu-operator.driver.rdma.enabled=true`; all other clusters explicitly receive `false`. `useHostMofed` remains unchanged.

## Validation

Validated with Go 1.25.8:

- `helm dependency update charts/kubernetes`
- `make touch`
- `make license`
- `make validate`
- `make lint`
- `make generate` with no generated-tree drift
- `make test-unit`
- default Helm render: controller flag absent
- configured Helm render: comma-separated region IDs passed to the controller

GitHub CI's Static, Runtime, and ConsumerContractTests jobs pass. The downstream `CanIDeploy` job cannot query the Pact broker from this fork PR because GitHub does not provide the broker secrets to fork workflows (`PACT_BROKER_URL` is empty); it fails before evaluating this commit.
