### PR TITLE
feat: add B200 RDMA application bundle

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -295,6 +295,31 @@ spec:
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: HelmApplication
 metadata:
+  name: {{ include "resource.id" "nvidia-hardware-enablement-rdma" }}
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+    unikorn-cloud.org/name: nvidia-hardware-enablement-rdma
+  annotations:
+    unikorn-cloud.org/description: |-
+      NVIDIA hardware enablement with the GPU driver's RDMA readiness path enabled.
+spec:
+  documentation: https://github.com/nscaledev/nvidia-platform-chart
+  license: Apache-2.0 License
+  versions:
+  - version: v0.1.2
+    repo: https://github.com/nscaledev/nvidia-platform-chart
+    path: chart
+    branch: nvidia-platform-0.1.2
+    namespace: kube-system
+    parameters:
+    - name: gpu-operator.driver.rdma.enabled
+      value: "true"
+    - name: gpu-operator.driver.rdma.useHostMofed
+      value: "false"
+---
+apiVersion: unikorn-cloud.org/v1alpha1
+kind: HelmApplication
+metadata:
   name: {{ include "resource.id" "amd-gpu-operator" }}
   labels:
     {{- include "unikorn.labels" . | nindent 4 }}

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -187,11 +187,11 @@ spec:
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: KubernetesClusterApplicationBundle
 metadata:
-  name: kubernetes-cluster-1.6.0-b200-rdma
+  name: kubernetes-cluster-1.6.1
   labels:
     {{- include "unikorn.labels" . | nindent 4 }}
 spec:
-  version: 1.6.0-b200.1
+  version: 1.6.1
   preview: true
   applications:
   - name: cluster-openstack

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -183,3 +183,69 @@ spec:
       kind: HelmApplication
       name: {{ include "resource.id" "gateway-api-crds" }}
       version: v1.3.0
+---
+apiVersion: unikorn-cloud.org/v1alpha1
+kind: KubernetesClusterApplicationBundle
+metadata:
+  name: kubernetes-cluster-1.6.0-b200-rdma
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  version: 1.6.0-b200.1
+  preview: true
+  applications:
+  - name: cluster-openstack
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-openstack" }}
+      version: 0.7.0
+  - name: cilium
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cilium" }}
+      version: 1.18.6
+  - name: openstack-cloud-provider
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "openstack-cloud-provider" }}
+      version: 2.32.0
+  - name: openstack-plugin-cinder-csi
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "openstack-plugin-cinder-csi" }}
+      version: 2.32.0
+  - name: metrics-server
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "metrics-server" }}
+      version: 3.12.2
+  - name: nvidia-hardware-enablement
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "nvidia-hardware-enablement-rdma" }}
+      version: v0.1.2
+  - name: cert-manager
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cert-manager" }}
+      version: v1.20.1
+  - name: amd-gpu-operator
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "amd-gpu-operator" }}
+      version: v1.2.0
+  - name: cluster-autoscaler
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-autoscaler" }}
+      version: 9.29.3
+  - name: cluster-autoscaler-openstack
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-autoscaler-openstack" }}
+      version: v0.1.0
+  - name: gateway-api-crds
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "gateway-api-crds" }}
+      version: v1.3.0


### PR DESCRIPTION
## Summary

- add a physical NVIDIA hardware-enablement application that enables the GPU driver RDMA readiness path while retaining `useHostMofed=false`
- add an opt-in preview Kubernetes 1.6.1 bundle for B200 clusters
- leave the existing stable bundle and NVIDIA v0.1.1 application unchanged

This isolates the generic MOFED/UMAD startup-order workaround to clusters that explicitly select the preview bundle. It supersedes the region-aware approach in #424.

Depends on nscaledev/nvidia-platform-chart#9 and the immutable `nvidia-platform-0.1.2` release it prepares.

## Validation

- `helm dependency update charts/kubernetes`
- `make touch`
- `make license`
- `make validate`
- `make lint`
- `make generate`
- generated-tree verification (`git diff --check`; only the two intended templates changed)
- `make test-unit`
- `helm lint --strict charts/kubernetes`
- rendered stable/default `1.6.0` and explicit preview `1.6.1` bundle references verified
